### PR TITLE
fix: Pinning onnxruntime to 1.15.1

### DIFF
--- a/label_studio_ml/examples/segment_anything_model/requirements.txt
+++ b/label_studio_ml/examples/segment_anything_model/requirements.txt
@@ -1,6 +1,6 @@
 label_studio_converter
 opencv-python
-onnxruntime
+onnxruntime<=1.15.1
 onnx
 torch==2.0.1
 torchvision==0.15.2


### PR DESCRIPTION
This way we can avoid triggering the #353 .
Alternative would be to drop the argument, but I assume that it is actually important to the function of the model.