### PR TITLE
Fixed bug in SamMLBackend.predict, enhanced documentation

### DIFF
--- a/label_studio_ml/examples/segment_anything_model/README.md
+++ b/label_studio_ml/examples/segment_anything_model/README.md
@@ -158,7 +158,8 @@ This step is only necessary if you are not using the Docker build for this model
 You can download all weights and models using the following command:
 
 ```bash
-./download_weights.sh
+./download_models.sh
+cp models/* .
 ```
 
 #### Install Requirements
@@ -172,7 +173,7 @@ pip install -r requirements.txt
 
 You can set the following environment variables to change the behavior of the model.
 
-* `LABEL_STUDIO_HOST` sets the endpoint of the Label Studio host.
+* `LABEL_STUDIO_HOST` sets the endpoint of the Label Studio host. Must begin with "http://" 
 * `LABEL_STUDIO_ACCESS_TOKEN` sets the API access token for the Label Studio host.
 * `SAM_CHOICE` selects which model to use.
     * `SAM_CHOICE=MobileSAM` to use MobileSAM (default)

--- a/label_studio_ml/examples/segment_anything_model/docker-compose.yml
+++ b/label_studio_ml/examples/segment_anything_model/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - SAM_CHOICE=MobileSAM
       - LOG_LEVEL=DEBUG
       # Add these variables if you want to access the images stored in Label Studio
-      - LABEL_STUDIO_HOST=http://...
+      - LABEL_STUDIO_HOST=  
       - LABEL_STUDIO_ACCESS_TOKEN=
     ports:
       - 9090:9090

--- a/label_studio_ml/examples/segment_anything_model/docker-compose.yml
+++ b/label_studio_ml/examples/segment_anything_model/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       # Change this to your model name
       - SAM_CHOICE=MobileSAM
       - LOG_LEVEL=DEBUG
-      # Add these variables if you want to access the images stored in Label Studio
+      # Add these variables if you want to access the images stored in Label Studio, host should start with http:// or https://
       - LABEL_STUDIO_HOST=  
       - LABEL_STUDIO_ACCESS_TOKEN=
     ports:

--- a/label_studio_ml/examples/segment_anything_model/docker-compose.yml
+++ b/label_studio_ml/examples/segment_anything_model/docker-compose.yml
@@ -13,12 +13,17 @@ services:
             memory: 8G
         reservations:
             memory: 4G
+# Add this to pass through 1 GPU 
+#            devices:
+#              - driver: nvidia
+#                count: 1
+#                capabilities: [gpu] 
     environment:
       # Change this to your model name
       - SAM_CHOICE=MobileSAM
       - LOG_LEVEL=DEBUG
       # Add these variables if you want to access the images stored in Label Studio
-      - LABEL_STUDIO_HOST=
+      - LABEL_STUDIO_HOST=http://...
       - LABEL_STUDIO_ACCESS_TOKEN=
     ports:
       - 9090:9090

--- a/label_studio_ml/examples/segment_anything_model/model.py
+++ b/label_studio_ml/examples/segment_anything_model/model.py
@@ -35,7 +35,7 @@ class SamMLBackend(LabelStudioMLBase):
             ctx_type = ctx['type']
             selected_label = ctx['value'][ctx_type][0]
             if ctx_type == 'keypointlabels':
-                point_labels.append(int(ctx['is_positive']))
+                point_labels.append(int(ctx.get('is_positive', 0)))
                 point_coords.append([int(x), int(y)])
             elif ctx_type == 'rectanglelabels':
                 box_width = ctx['value']['width'] * image_width / 100


### PR DESCRIPTION
The segment-anything-model backend did not work for me for a couple of reasons:
1. There seems to be a bug in https://github.com/HumanSignal/label-studio-ml-backend/blob/193e24e95539371f53d93d6bee3d8cf684326857/label_studio_ml/examples/segment_anything_model/model.py#L38 The key `is_positive` is not always present
2. When running the docker image the backend is run with `exec gunicorn --preload --bind :$PORT --workers 1 --threads 8 --timeout 0 _wsgi:app`. This creates problems with CUDA ("[Cannot re-initialize CUDA in forked subprocess](https://stackoverflow.com/questions/72779926/gunicorn-cuda-cannot-re-initialize-cuda-in-forked-subprocess)"). The problem is described and discussed in more detail here: https://stackoverflow.com/questions/72779926/gunicorn-cuda-cannot-re-initialize-cuda-in-forked-subprocess. My simple fix is to run `python _wsgi.py` instead.
3. It should be pointed our more clearly that the environment variable `LABEL_STUDIO_HOST` must start with `http://`, otherwise fetching the images from label studio won't work.
4. The documentation states `./download_weights.sh` will download the model weights for SAM and MobileSAM. The file has a different name however and the downloads should be places in the root folder instead of `models/`. 

The pull requested contains clarifications / fixes for all these issues.