### PR TITLE
Update broken import

### DIFF
--- a/label_studio_ml/response.py
+++ b/label_studio_ml/response.py
@@ -2,7 +2,7 @@
 from typing import Type, Dict, Optional, List, Tuple, Any, Union
 from pydantic import BaseModel, confloat
 
-from label_studio_sdk.objects import PredictionValue
+from label_studio_sdk._legacy.objects import PredictionValue
 
 
 class ModelResponse(BaseModel):


### PR DESCRIPTION
Recently in [label-studio-sdk](https://github.com/HumanSignal/label-studio-sdk) `objects` was moved to `_legacy`