### PR TITLE
Correct tag name for grounding_sam in compose.

### DIFF
--- a/label_studio_ml/examples/grounding_sam/docker-compose.yml
+++ b/label_studio_ml/examples/grounding_sam/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.11"
 services:
   grounding_sam:
     container_name: grounding_sam
-    image: heartexlabs/label-studio-ml-backend:grndsam-master
+    image: heartexlabs/label-studio-ml-backend:grounding_sam-master
     build:
       context: .
       args:


### PR DESCRIPTION
The previous docker tag "grndsam-master" does not exist on the docker hub. However, "heartexlabs/label-studio-ml-backend:grounding_sam-master" does