### PR TITLE
Workaround to avoid duplicate annotations

### DIFF
--- a/label_studio_ml/examples/grounding_sam/dino.py
+++ b/label_studio_ml/examples/grounding_sam/dino.py
@@ -135,6 +135,10 @@ class DINOBackend(LabelStudioMLBase):
         if not context or not context.get('result'):
             # if there is no context, no interaction has happened yet
             return []
+        
+        if len(context['result'][0]['value']['text']) > 1:
+            # workaround for labelstudio running interactive annotations on submit
+            return []
 
         from_name_r, to_name_r, value = self.get_first_tag_occurence('RectangleLabels', 'Image')
         from_name_b, to_name_b, _ = self.get_first_tag_occurence('BrushLabels', 'Image')


### PR DESCRIPTION
https://github.com/HumanSignal/label-studio/issues/6312 causes an extra call to `predict` when 'Submit' is clicked, causing duplicate predictions. This is a workaround that shouldn't impact the functionality (handling an edge case that shouldn't happen anyway) and will prevent the problem by returning empty annotations the second time (when the prompt is duplicated).

This assumes the auto-annotation has been used before clicking submit. If it weren't used then the prompt length would be 1 and this fix wouldn't work. As stated, this is a workaround, the real fix should be to avoid LabelStudio calling the prediction endpoint on submit.