### PR TITLE
docs: Fix Docker command in Tesseract readme and WatsonX frontmatter

### DIFF
--- a/label_studio_ml/examples/tesseract/README.md
+++ b/label_studio_ml/examples/tesseract/README.md
@@ -45,7 +45,7 @@ Launch Label Studio. You can follow the guide from the [official documentation](
    docker run -it \
       -p 8080:8080 \
       -v `pwd`/mydata:/label-studio/data \
-      heartex/label-studio:latest
+      heartexlabs/label-studio:latest
    ```
 
    Optionally, you may enable local file serving in Label Studio
@@ -56,7 +56,7 @@ Launch Label Studio. You can follow the guide from the [official documentation](
       -v `pwd`/mydata:/label-studio/data \
       --env LABEL_STUDIO_LOCAL_FILES_SERVING_ENABLED=true \
       --env LABEL_STUDIO_LOCAL_FILES_DOCUMENT_ROOT=/label-studio/data/images \
-      heartex/label-studio:latest
+      heartexlabs/label-studio:latest
    ```
    If you're using local file serving, be sure to [get a copy of the API token](https://labelstud.io/guide/user_account#Access-token) from
    Label Studio to connect the model.

--- a/label_studio_ml/examples/watsonx_llm/README.md
+++ b/label_studio_ml/examples/watsonx_llm/README.md
@@ -8,7 +8,7 @@ hide_menu: true
 hide_frontmatter_title: true
 meta_title: Integrate WatsonX with Label Studio
 categories:
-    - Computer Vision
+    - Generative AI
     - Large Language Model
     - WatsonX
 image: "/tutorials/watsonx.png"


### PR DESCRIPTION
Tesseract: Should be `heartexlabs` and not `heartex`

WatsonX: Generative AI is a better category