### PR TITLE
docs: Add links to ml-backend directory

### DIFF
--- a/label_studio_ml/examples/bert_classifier/README.md
+++ b/label_studio_ml/examples/bert_classifier/README.md
@@ -27,6 +27,12 @@ The NewModel is a BERT-based text classification model that is designed to work 
 - Automatically download the labeled tasks from Label Studio and prepare the data for training.
 - Customize the training parameters such as learning rate, number of epochs, and weight decay.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`bert_classifier` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/bert_classifier). 
+
 
 ## Running with Docker (recommended)
 

--- a/label_studio_ml/examples/easyocr/README.md
+++ b/label_studio_ml/examples/easyocr/README.md
@@ -24,6 +24,12 @@ The primary function of this connection is to recognize and extract text from im
 
 In the context of Label Studio, this connection enhances the platform's labeling capabilities, allowing users to automatically generate labels for text in images. This can be particularly useful in tasks such as data annotation, document digitization, and more.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`easyocr` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/easyocr). 
+
 ## Labeling configuration
 
 The EasyOCR model connection can be used with the default labeling configuration for OCR in Label Studio. This configuration typically involves defining the types of labels to be used (e.g., text, handwriting, etc.) and the regions of the image where these labels should be applied.

--- a/label_studio_ml/examples/flair/README.md
+++ b/label_studio_ml/examples/flair/README.md
@@ -20,6 +20,12 @@ image: "/tutorials/flair.png"
 
 This example demonstrates how to use Flair NER model with Label Studio.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`flair` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/flair). 
+
 ## Quickstart
 
 1. Build and start the Machine Learning backend on `http://localhost:9090`

--- a/label_studio_ml/examples/gliner/README.md
+++ b/label_studio_ml/examples/gliner/README.md
@@ -24,6 +24,12 @@ The GLiNER model is a BERT family model for generalist NER. We download the mode
 model is
 available on [GitHub](https://github.com/urchade/GLiNER).
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`gliner` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/gliner). 
+
 
 ## Running with Docker (recommended)
 

--- a/label_studio_ml/examples/grounding_dino/README.md
+++ b/label_studio_ml/examples/grounding_dino/README.md
@@ -29,6 +29,12 @@ This integration will allow you to:
 
 See [here](https://github.com/IDEA-Research/GroundingDINO) for more details about the pre-trained Grounding DINO model. 
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`grounding_dino` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/grounding_dino). 
+
 
 ## Quickstart
 

--- a/label_studio_ml/examples/grounding_sam/README.md
+++ b/label_studio_ml/examples/grounding_sam/README.md
@@ -32,6 +32,12 @@ This integration will allow you to:
 
 See [here](https://github.com/IDEA-Research/GroundingDINO) for more details about the pre-trained Grounding DINO model. 
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`grounding_sam` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/grounding_sam). 
+
 
 ## Quickstart
 

--- a/label_studio_ml/examples/huggingface_llm/README.md
+++ b/label_studio_ml/examples/huggingface_llm/README.md
@@ -23,6 +23,12 @@ This machine learning backend is designed to work with Label Studio, providing a
 
 Check [text generation pipelines on Hugging Face](https://huggingface.co/tasks/text-generation) for more details.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`huggingface_llm` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/huggingface_llm). 
+
 ## Label Studio XML labeling config
 
 This ML backend is compatible with a Label Studio labeling configuration that uses a `<TextArea>` tag. Here is an example of a compatible labeling configuration:

--- a/label_studio_ml/examples/huggingface_ner/README.md
+++ b/label_studio_ml/examples/huggingface_ner/README.md
@@ -25,7 +25,13 @@ The model instantiates `AutoModelForTokenClassification` from Hugging Face's tra
 - If you want to use this model only in inference mode, it serves predictions from the pre-trained model. 
 - If you want to fine-tune the model, you can use the Label Studio interface to provide training data and train the model.
 
-Read more about the compatible models from [Hugging Face's official documentation](https://huggingface.co/docs/transformers/en/tasks/token_classification)
+Read more about the compatible models from [Hugging Face's official documentation](https://huggingface.co/docs/transformers/en/tasks/token_classification). 
+
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`huggingface_ner` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/huggingface_ner). 
 
 
 ## Labeling configuration

--- a/label_studio_ml/examples/interactive_substring_matching/README.md
+++ b/label_studio_ml/examples/interactive_substring_matching/README.md
@@ -20,6 +20,12 @@ image: "/tutorials/interactive-substring-matching.png"
 
 The Machine Learning (ML) backend is designed to enhance the efficiency of auto-labeling in Named Entity Recognition (NER) tasks. It achieves this by selecting a keyword and automatically matching the same keyword in the provided text. 
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`interactive_substring_matching` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/interactive_substring_matching). 
+
 ## Recommended labeling config
 
 This ML backend works with the default NER template from Label Studio. You can find this by selecting Label Studio's pre-built NER template when configuring the labeling interface. It is available under **Natural Language Processing > Named Entity Recognition**.

--- a/label_studio_ml/examples/langchain_search_agent/README.md
+++ b/label_studio_ml/examples/langchain_search_agent/README.md
@@ -27,6 +27,12 @@ This example demonstrates how to use Label Studio with a custom Machine Learning
 It uses a [Langchain](https://www.langchain.com/)-based agent that accepts a text input, searches for Google,
 and returns the answer based on the search results (a.k.a Retrieval Augmented Generation).
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`langchain_search_agent` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/langchain_search_agent). 
+
 ## Prerequisites
 
 ### Use Google Search

--- a/label_studio_ml/examples/llm_interactive/README.md
+++ b/label_studio_ml/examples/llm_interactive/README.md
@@ -35,6 +35,12 @@ The interactive flow allows you to perform the following scenarios:
 
 Check the [Generative AI templates](https://labelstud.io/templates/gallery_generative_ai) section for more examples.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`llm_interactive` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/llm_interactive). 
+
 ## Quickstart
 
 1. Build and start the Machine Learning backend on `http://localhost:9090` <br /><br />

--- a/label_studio_ml/examples/mmdetection-3/README.md
+++ b/label_studio_ml/examples/mmdetection-3/README.md
@@ -27,6 +27,12 @@ The model is based on the YOLOv3 architecture with a MobileNetV2 backbone and tr
 
 ![screenshot.png](screenshot.png)
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`mmdetection-3` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/mmdetection-3). 
+
 ## Quick usage
 
 For quick usage run `docker-compose` in your working directory:

--- a/label_studio_ml/examples/nemo_asr/README.md
+++ b/label_studio_ml/examples/nemo_asr/README.md
@@ -23,6 +23,12 @@ This example demonstrates how to use the [NeMo](https://github.com/NVIDIA/NeMo/b
 
 Use this model if you want to transcribe and fix your audio data.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`nemo_asr` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/nemo_asr). 
+
 ## Labeling interface
 
 This example works with the Label Studio's pre-built **Audio Transcription** template (available under **Audio Processing > Audio Transcription**).  

--- a/label_studio_ml/examples/segment_anything_2_image/README.md
+++ b/label_studio_ml/examples/segment_anything_2_image/README.md
@@ -27,6 +27,12 @@ You'll need to follow the instructions below to stand up an instance of SAM2 bef
 
 [![Connecting SAM2 Model to Label Studio for Image Annotation ](https://img.youtube.com/vi/FTg8P8z4RgY/0.jpg)](https://www.youtube.com/watch?v=FTg8P8z4RgY)
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`segment_anything_2_image` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/segment_anything_2_image). 
+
 Note that as of 8/1/2024, SAM2 only runs on GPU.
 
 ## Labeling configuration

--- a/label_studio_ml/examples/segment_anything_2_video/README.md
+++ b/label_studio_ml/examples/segment_anything_2_video/README.md
@@ -25,6 +25,12 @@ see the [segment_anything_2_image repository](https://github.com/HumanSignal/lab
 
 ![sam2](./Sam2Video.gif)
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`segment_anything_2_video` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/segment_anything_2_video). 
+
 ## Running from source
 
 1. To run the ML backend without Docker, you have to clone the repository and install all dependencies using pip:

--- a/label_studio_ml/examples/segment_anything_model/README.md
+++ b/label_studio_ml/examples/segment_anything_model/README.md
@@ -27,6 +27,12 @@ Use Facebook's Segment Anything Model with Label Studio!
 In July 2024, Facebook released an update to the Segement Anything model, called SAM 2. To use this newer model for 
 labeling, see [the segment_anything_2_image repo](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/segment_anything_2_image)
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`segment_anything_model` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/segment_anything_model). 
+
 ## Quickstart
 
 ### Using Docker Compose (recommended)

--- a/label_studio_ml/examples/sklearn_text_classifier/README.md
+++ b/label_studio_ml/examples/sklearn_text_classifier/README.md
@@ -22,6 +22,12 @@ The Sklearn Text Classifier model is a custom machine learning backend for Label
 
 The model is trained on the labeled texts collected from Label Studio, and it uses the Label Studio API to fetch the labeled tasks for training. This integration with Label Studio allows for a seamless and efficient labeling workflow, as the model can be retrained and updated as new labeled data becomes available.
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`sklearn_text_classifier` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/sklearn_text_classifier). 
+
 ## Labeling configuration
 
 The Sklearn Text Classifier model is designed to work with the default labeling configuration for text classification in Label Studio. This configuration includes a single `<Choices>` output and a single `<Text>` input. The model retrieves the first occurrence of these tags from the labeling configuration and uses them for its prediction:

--- a/label_studio_ml/examples/spacy/README.md
+++ b/label_studio_ml/examples/spacy/README.md
@@ -22,6 +22,11 @@ Current implementation includes the following models:
 - Named Entity Recognition (NER)
 - [coming soon...] Part-of-Speech (POS) tagging
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`spacy` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/spacy). 
 
 ## Quickstart
 

--- a/label_studio_ml/examples/tesseract/README.md
+++ b/label_studio_ml/examples/tesseract/README.md
@@ -29,13 +29,16 @@ Tested against Label Studio 1.10.1, with basic support for both Label Studio
 Local File Storage and S3-compatible storage, with a example data storage with
 MinIO.
 
-## Setup process
+## Before you begin
 
 Before you begin:
 * Ensure git is installed
 * Ensure Docker Compose is installed. For MacOS and Windows users,
    we suggest using Docker Desktop. 
 
+You must also install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`tesseract` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/tesseract). 
 
 ### 1. Install Label Studio
 

--- a/label_studio_ml/examples/watsonx_llm/README.md
+++ b/label_studio_ml/examples/watsonx_llm/README.md
@@ -31,6 +31,12 @@ See the configuration notes at the bottom for details on how to set up your envi
 
 For a video demonstration, see [Integrating Label Studio with IBM WatsonX](https://www.youtube.com/watch?v=9iP2yO4Geqc).
 
+## Before you begin
+
+Before you begin, you must install the [Label Studio ML backend](https://github.com/HumanSignal/label-studio-ml-backend?tab=readme-ov-file#quickstart). 
+
+This tutorial uses the [`watsonx_llm` example](https://github.com/HumanSignal/label-studio-ml-backend/tree/master/label_studio_ml/examples/watsonx_llm). 
+
 ## Setting up your label_config
 For this project, we recommend you start with the labeling config as defined below, but you can always edit it or expand it to
 meet your needs! Crucially, there must be a `<TextArea>` tag for the model to insert its response into. 

--- a/label_studio_ml/examples/yolo/README.md
+++ b/label_studio_ml/examples/yolo/README.md
@@ -99,7 +99,8 @@ This tutorial uses the [YOLO example](https://github.com/HumanSignal/label-studi
 
 - `<RectangleLabels>` - [Bounding boxes](https://labelstud.io/tags/rectanglelabels); object detection task
 - `<PolygonLabels>` - [Polygons](https://labelstud.io/tags/polygonlables); segmentation task
-- `<VideoRectangle>` - [Video bounding boxes](https://labelstud.io/tags/videorectangle); object tracking task
+- `<VideoRectangle>` - [Video bounding boxes](https://labelstud.io/tags/videorectangle); video object tracking task
+- `<KeyPointLabels>` - [Key points](https://labelstud.io/tags/keypointlabels); pose detection task
 - `<Choices>` - [Classification](https://labelstud.io/tags/choices)
 
 **How to skip the control tag?**


### PR DESCRIPTION
Adding links to the example directory to add context when users are finding the tutorial through the ML tutorials page on the docs website. 