### PR TITLE
fix: Escaping in wsgi template

### DIFF
--- a/label_studio_ml/default_configs/_wsgi.py.tmpl
+++ b/label_studio_ml/default_configs/_wsgi.py.tmpl
@@ -7,30 +7,30 @@ import logging.config
 # Set a default log level if LOG_LEVEL is not defined
 log_level = os.getenv("LOG_LEVEL", "INFO")
 
-logging.config.dictConfig(
-    {
-        "version": 1,
-        "disable_existing_loggers": False,  # Prevent overriding existing loggers
-        "formatters": {
-            "standard": {
-                "format": "[%(asctime)s] [%(levelname)s] [%(name)s::%(funcName)s::%(lineno)d] %(message)s"
-            }
-        },
-        "handlers": {
-            "console": {
-                "class": "logging.StreamHandler",
-                "level": log_level,
-                "stream": "ext://sys.stdout",
-                "formatter": "standard",
-            }
-        },
-        "root": {
-            "level": log_level,
-            "handlers": ["console"],
-            "propagate": True,
-        },
-    }
-)
+logging.config.dictConfig({{
+  "version": 1,
+  "disable_existing_loggers": False,  # Prevent overriding existing loggers
+  "formatters": {{
+    "standard": {{
+      "format": "[%(asctime)s] [%(levelname)s] [%(name)s::%(funcName)s::%(lineno)d] %(message)s"
+    }}
+  }},
+  "handlers": {{
+    "console": {{
+      "class": "logging.StreamHandler",
+      "level": log_level,
+      "stream": "ext://sys.stdout",
+      "formatter": "standard"
+    }}
+  }},
+  "root": {{
+    "level": log_level,
+    "handlers": [
+      "console"
+    ],
+    "propagate": True
+  }}
+}})
 
 from label_studio_ml.api import init_app
 from {script} import {model_class}


### PR DESCRIPTION
```
logging.config.dictConfig({{
}})
```
was accidentally replaced to 
```
logging.config.dictConfig({
})
```

This PR fixes it. 