### PR TITLE
[#681] Speed up quitting the EasyOCR container.

### DIFF
--- a/label_studio_ml/examples/easyocr/docker-compose.yml
+++ b/label_studio_ml/examples/easyocr/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   easyocr:
     container_name: easyocr
     image: heartexlabs/label-studio-ml-backend:easyocr-master
+    init: true
     build:
       context: .
       args:


### PR DESCRIPTION
Tested on:
macOS Sequoia 15.2
Docker Desktop 4.37.1
Docker compose v2.31.0-desktop.2