### PR TITLE
Fix: Grounding Sam and Grounding Dino

### DIFF
--- a/label_studio_ml/examples/grounding_dino/requirements.txt
+++ b/label_studio_ml/examples/grounding_dino/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==22.0.0
 label-studio-ml @ git+https://github.com/HumanSignal/label-studio-ml-backend.git@master
 olefile==0.47
-
+accelerate==1.6.0

--- a/label_studio_ml/examples/grounding_sam/requirements.txt
+++ b/label_studio_ml/examples/grounding_sam/requirements.txt
@@ -7,5 +7,6 @@ mobile-sam @ git+https://github.com/ChaoningZhang/MobileSAM.git
 segment-anything==1.0
 olefile==0.47
 # networkx==2.8.8
+accelerate==1.6.0
 
 


### PR DESCRIPTION
Need to add accelerate==1.6.0 to the requirements for both grounding models. 