### PR TITLE
[fix] Fix KeyError getting project id for HuggingFace and Sklearn bac…

### DIFF
--- a/label_studio_ml/examples/bert_classifier/model.py
+++ b/label_studio_ml/examples/bert_classifier/model.py
@@ -122,7 +122,8 @@ class BertClassifier(LabelStudioMLBase):
         if event not in ('ANNOTATION_CREATED', 'ANNOTATION_UPDATED', 'START_TRAINING'):
             logger.info(f"Skip training: event {event} is not supported")
             return
-        project_id = data['annotation']['project']
+        logger.debug(f"Project details payload for training: {data}")
+        project_id = data['project']['id']
 
         # dowload annotated tasks from Label Studio
         ls = label_studio_sdk.Client(self.LABEL_STUDIO_HOST, self.LABEL_STUDIO_API_KEY)

--- a/label_studio_ml/examples/huggingface_ner/model.py
+++ b/label_studio_ml/examples/huggingface_ner/model.py
@@ -52,7 +52,7 @@ class HuggingFaceNER(LabelStudioMLBase):
         from_name, _, _ = li.get_first_tag_occurence('Labels', 'Text')
         tag = li.get_tag(from_name)
         return tag.labels
-    
+
     def setup(self):
         """Configure any paramaters of your model here
         """
@@ -102,7 +102,7 @@ class HuggingFaceNER(LabelStudioMLBase):
                     'score': avg_score / len(results),
                     'model_version': self.get('model_version')
                 })
-        
+
         return ModelResponse(predictions=predictions, model_version=self.get('model_version'))
 
     def _get_tasks(self, project_id):
@@ -135,7 +135,7 @@ class HuggingFaceNER(LabelStudioMLBase):
 
         tokenized_inputs["labels"] = labels
         return tokenized_inputs
-    
+
     def fit(self, event, data, **kwargs):
         """Download dataset from Label Studio and prepare data for training in BERT
         """
@@ -143,7 +143,8 @@ class HuggingFaceNER(LabelStudioMLBase):
             logger.info(f"Skip training: event {event} is not supported")
             return
 
-        project_id = data['annotation']['project']
+        logger.debug(f"Project details payload for training: {data}")
+        project_id = data['project']['id']
         tasks = self._get_tasks(project_id)
 
         if len(tasks) % self.START_TRAINING_EACH_N_UPDATES != 0 and event != 'START_TRAINING':

--- a/label_studio_ml/examples/sklearn_text_classifier/model.py
+++ b/label_studio_ml/examples/sklearn_text_classifier/model.py
@@ -74,7 +74,7 @@ class SklearnTextClassifier(LabelStudioMLBase):
             'value': value,
             'labels': labels
         }
-        
+
     def predict(self, tasks: List[Dict], context: Optional[Dict] = None, **kwargs) -> ModelResponse:
         """
         This method is used to predict the labels for a given list of tasks.
@@ -162,7 +162,8 @@ class SklearnTextClassifier(LabelStudioMLBase):
             logger.info(f"Skip training: event {event} is not supported")
             return
 
-        project_id = data['annotation']['project']
+        logger.debug(f"Project details payload for training: {data}")
+        project_id = data['project']['id']
         tasks = self._get_tasks(project_id)
 
         # Get the labeling configuration parameters like labels and input / output annotation format names


### PR DESCRIPTION
This fixes a problem retrieving the project ID during the webhook for model training in the huggingface_ner, bert_classifier, and sklearn_text_classifier backends, resolving https://github.com/HumanSignal/label-studio-ml-backend/issues/768 and https://github.com/HumanSignal/label-studio-ml-backend/issues/745. There is also some trailing whitespace removed in the respective backend's model.py files to be consistent with PEP8. 

I confirmed by rebuilding and running the backends in docker containers that I am now able to successfully complete training after triggering it in the "Model" section of project settings with huggingface_ner, bert_classifier, and sklearn_text_classifier backends.

Previously, when model training was triggered, a KeyError arose as follows:
```
bert_classifier  | [2025-06-25 16:28:19,504] [ERROR] [label_studio_ml.api::log_exception::875] Exception on /webhook [POST]
bert_classifier  | Traceback (most recent call last):
bert_classifier  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
bert_classifier  |     response = self.full_dispatch_request()
bert_classifier  |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
bert_classifier  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
bert_classifier  |     rv = self.handle_user_exception(e)
bert_classifier  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
bert_classifier  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
bert_classifier  |     rv = self.dispatch_request()
bert_classifier  |          ^^^^^^^^^^^^^^^^^^^^^^^
bert_classifier  |   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
bert_classifier  |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
bert_classifier  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
bert_classifier  |   File "/usr/local/lib/python3.11/site-packages/label_studio_ml/api.py", line 126, in webhook
bert_classifier  |     result = model.fit(event, data)
bert_classifier  |              ^^^^^^^^^^^^^^^^^^^^^^
bert_classifier  |   File "/app/model.py", line 125, in fit
bert_classifier  |     project_id = data['annotation']['project']
bert_classifier  |                  ~~~~^^^^^^^^^^^^^^
bert_classifier  | KeyError: 'annotation'
```
