### PR TITLE
Add CACHE_DIR to allow moving cache location

### DIFF
--- a/label_studio_ml/model.py
+++ b/label_studio_ml/model.py
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 CACHE = create_cache(
     os.getenv('CACHE_TYPE', 'sqlite'),
     path=os.getenv('CACHE_DIR', os.getenv('MODEL_DIR', '.'))
+)
 
 
 # Decorator to register predict function

--- a/label_studio_ml/model.py
+++ b/label_studio_ml/model.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 CACHE = create_cache(
     os.getenv('CACHE_TYPE', 'sqlite'),
-    path=os.getenv('MODEL_DIR', '.'))
+    path=os.getenv('CACHE_DIR', os.getenv('MODEL_DIR', '.'))
 
 
 # Decorator to register predict function


### PR DESCRIPTION
Currently the model cache file is written to the location of the `MODEL_DIR` environment variable if set.

I want to deploy the label studio ML backend to an Azure container app. My model is persisted to an Azure storage file share mounted at _/app/models_ and so my `MODEL_DIR` is set to _/app/models_.

But Azure files don't work with Sqlite database, and it will error with `Error: SQLITE_BUSY: database is locked`

I want to add a new `CACHE_DIR` environment variable which will allow the cache to be moved to an alternative location inside the container which should fix my problem.

If not set, it will fallback to using `MODEL_DIR` so it shouldn't cause any problems for existing users.

I haven't tested this (sorry!).