### PR TITLE
fix: label-studio-sdk version conflict with label-studio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ colorama~=0.4
 requests~=2.31
 semver~=3.0.2
 # label-studio-sdk==1.0.2
-label-studio-sdk @ git+https://github.com/HumanSignal/label-studio-sdk.git
+label-studio-sdk==2.0.18


### PR DESCRIPTION
This PR resolves a dependency mismatch caused by installing `label-studio-sdk` from a floating git source, which may resolve to versions incompatible with `label-studio==1.23.0`, which is the latest version as of today. 

### Issue
- `label-studio==1.23.0` requires `label-studio-sdk==2.0.18`
- Current `requirements.txt` installs the SDK from git, which resolves to a newer version, causing potential conflicts

This can result in `ResolutionImpossible` errors when both dependencies are installed together. 

### Fix
Pin `label-studio-sdk` to the compatible version.

Closes #869 