### PR TITLE
fix: BROS-1416: Seems like SAM2 is sometimes returning results for the wrong frame

### DIFF
--- a/label_studio_ml/examples/segment_anything_video_interactive/frame_resolve.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/frame_resolve.py
@@ -1,0 +1,48 @@
+"""Pure frame-index resolution for the SAM2 video interactive backend.
+
+Kept free of heavy deps (torch/cv2/SAM2) so the conversion logic can be
+unit-tested in isolation — see ``test_frame_resolve.py``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+
+def resolve_frame_index(
+    time_ms: Optional[float],
+    frame: Optional[int],
+    fps: Optional[float],
+    frame_count: Optional[int],
+) -> int:
+    """Translate an FE-supplied timestamp (ms) or 1-indexed frame into the
+    BE's 0-indexed frame space.
+
+    ``time_ms`` wins over ``frame``: timestamps are fps-agnostic, while
+    ``frame`` carries the FE's config-fps assumption. If only ``frame`` is
+    provided we fall back to the legacy N-1 mapping (FE is 1-indexed).
+
+    The browser renders the frame whose start timestamp is <= currentTime,
+    i.e. ``floor(currentTime * fps)``. When seeking, the FE nudges currentTime
+    a couple of milliseconds *past* the frame boundary (BROWSER_TIME_PRECISION)
+    so that frame is the one on screen, then sends ``time_ms = currentTime*1000``.
+    Using ``math.floor`` here therefore picks exactly the on-screen frame.
+
+    ``round()`` would tip to the *next* frame whenever the timestamp crosses
+    the half-frame mark — common when the FE config framerate differs from the
+    real video fps — sending SAM2 a frame ahead of what the user sees
+    (BROS-1416: "SAM2 returns results for the wrong frame; move a frame forward
+    and it matches").
+    """
+    if time_ms is not None:
+        try:
+            ms = float(time_ms)
+        except (TypeError, ValueError):
+            ms = None
+        if ms is not None and fps:
+            idx = math.floor((ms / 1000.0) * fps)
+            if frame_count is not None:
+                idx = min(idx, max(0, frame_count - 1))
+            return max(0, idx)
+    return max(0, int(frame if frame is not None else 1) - 1)

--- a/label_studio_ml/examples/segment_anything_video_interactive/model.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/model.py
@@ -34,6 +34,7 @@ from label_studio_ml.response import ModelResponse
 from label_studio_sdk.label_interface.objects import PredictionValue
 
 from frame_cache import FrameCache
+from frame_resolve import resolve_frame_index
 from mask_encoding import (
     mask_to_bbox_percent,
     mask_to_bitmap_png_base64,
@@ -236,21 +237,15 @@ def _resolve_be_frame(context: Dict[str, Any], video) -> int:
     """Translate a frontend-supplied timestamp (ms) or 1-indexed frame into
     the BE's 0-indexed frame space using the video's own fps.
 
-    `time_ms` wins over `frame`: timestamps are fps-agnostic, while `frame`
-    carries the FE's config-fps assumption. If only `frame` is provided we
-    fall back to the legacy N-1 mapping (FE is 1-indexed).
+    Delegates to the dependency-free :func:`resolve_frame_index` so the
+    conversion can be unit-tested without torch/cv2 (see test_frame_resolve.py).
     """
-    raw_ms = context.get("time_ms")
-    if raw_ms is not None:
-        try:
-            ms = float(raw_ms)
-        except (TypeError, ValueError):
-            ms = None
-        if ms is not None and video.fps:
-            idx = int(round((ms / 1000.0) * video.fps))
-            max_idx = max(0, video.frame_count - 1)
-            return max(0, min(idx, max_idx))
-    return max(0, int(context.get("frame", 1)) - 1)
+    return resolve_frame_index(
+        context.get("time_ms"),
+        context.get("frame", 1),
+        video.fps,
+        video.frame_count,
+    )
 
 
 def _object_score(inference_state, obj_idx: int, frame_idx: int) -> Optional[float]:

--- a/label_studio_ml/examples/segment_anything_video_interactive/test_frame_resolve.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/test_frame_resolve.py
@@ -1,0 +1,70 @@
+"""Unit tests for resolve_frame_index (BROS-1416).
+
+These run without torch/cv2/SAM2: the frame-resolution math lives in the
+dependency-free ``frame_resolve`` module so it can be exercised in isolation.
+
+Run with: pytest test_frame_resolve.py -v
+"""
+
+from frame_resolve import resolve_frame_index
+
+
+def test_time_ms_resolves_to_displayed_frame_not_next():
+    """Regression for BROS-1416.
+
+    The FE seeks ~2ms past a frame boundary (BROWSER_TIME_PRECISION) so the
+    browser renders the intended frame, then sends ``time_ms = currentTime*1000``.
+    The browser displays ``floor(currentTime * fps)``. When the FE config
+    framerate differs from the real video fps the timestamp can land in the
+    *upper* half of a real-fps frame interval — e.g. config 25fps frame 4
+    (0-based 3 -> 3/25 + 0.002 = 0.122s) against a real 30fps video:
+    0.122 * 30 = 3.66, so the on-screen frame is floor(3.66) == 3.
+
+    ``round(3.66) == 4`` would send SAM2 the *next* frame, which is the bug.
+    """
+    idx = resolve_frame_index(time_ms=122.0, frame=4, fps=30.0, frame_count=1000)
+    assert idx == 3
+
+
+def test_time_ms_on_boundary_nudge_stays_on_frame():
+    """A timestamp nudged just past a frame's start resolves to that frame."""
+    # 0-based frame 160 at 30fps starts at 160/30 = 5.33333s; FE nudges +2ms.
+    time_ms = (160 / 30.0) * 1000 + 2
+    assert resolve_frame_index(time_ms=time_ms, frame=161, fps=30.0, frame_count=1000) == 160
+
+
+def test_time_ms_zero_is_first_frame():
+    assert resolve_frame_index(time_ms=0.0, frame=1, fps=30.0, frame_count=1000) == 0
+
+
+def test_time_ms_clamped_to_last_frame():
+    # Way past the end -> clamped to frame_count - 1.
+    assert resolve_frame_index(time_ms=10_000_000.0, frame=1, fps=30.0, frame_count=300) == 299
+
+
+def test_falls_back_to_frame_when_no_time_ms():
+    # Legacy 1-indexed FE frame -> 0-indexed BE frame.
+    assert resolve_frame_index(time_ms=None, frame=161, fps=30.0, frame_count=1000) == 160
+
+
+def test_falls_back_to_frame_when_fps_missing():
+    assert resolve_frame_index(time_ms=5000.0, frame=42, fps=0, frame_count=1000) == 41
+    assert resolve_frame_index(time_ms=5000.0, frame=42, fps=None, frame_count=1000) == 41
+
+
+def test_falls_back_to_frame_when_time_ms_invalid():
+    assert resolve_frame_index(time_ms="not-a-number", frame=42, fps=30.0, frame_count=1000) == 41
+
+
+def test_frame_defaults_to_one_when_absent():
+    assert resolve_frame_index(time_ms=None, frame=None, fps=30.0, frame_count=1000) == 0
+
+
+def test_floor_matches_browser_across_a_sweep():
+    """For any currentTime, the resolved frame equals the frame the browser
+    shows: floor(currentTime * fps). round() diverges on upper-half timestamps.
+    """
+    fps = 30.0
+    for ms in range(0, 5000, 7):
+        expected = int((ms / 1000.0) * fps)  # floor for non-negative
+        assert resolve_frame_index(time_ms=float(ms), frame=1, fps=fps, frame_count=100000) == expected


### PR DESCRIPTION
## Summary

SAM2 video interactive sometimes returned a segmentation matching a frame **one ahead** of the one the user was viewing — "move a frame or two forward and it's a perfect match" (BROS-1416).

**Root cause:** `_resolve_be_frame` (in `segment_anything_video_interactive/model.py`) converted the FE-supplied timestamp to a 0-based frame index with `int(round((ms/1000)*fps))`.

The browser renders the frame whose start timestamp is `<= currentTime`, i.e. `floor(currentTime*fps)`. On seek, the FE nudges `currentTime` a couple of ms **past** the frame boundary (`BROWSER_TIME_PRECISION = 0.002` in `VideoCanvas.tsx`) so that frame is the one on screen, then sends `time_ms = currentTime*1000`. `round()` tips to the **next** frame whenever the timestamp crosses the half-frame mark — which happens unpredictably ("sometimes"), and is amplified when the FE config `framerate` differs from the real video fps. SAM2 then segmented a frame ahead of what the user saw.

**Fix:** use `math.floor` so the backend picks exactly the on-screen frame. The conversion is extracted into a dependency-free `frame_resolve.resolve_frame_index` (no torch/cv2) so it can be unit-tested; `_resolve_be_frame` delegates to it. `time_ms`-wins-over-`frame`, the legacy 1-indexed fallback, and `[0, frame_count-1]` clamping are all preserved — only `round`→`floor` changes.

## Test plan

`pytest label_studio_ml/examples/segment_anything_video_interactive/test_frame_resolve.py -v` — 9 tests, run without heavy deps:

- **Regression (red→green):** an upper-half-interval timestamp (fps-mismatch case) resolves to the displayed frame, not the next — fails under `round` (`4`), passes under `floor` (`3`).
- Boundary nudge stays on frame; `time_ms=0`; clamp to `frame_count-1`.
- Legacy `frame` fallback (no `time_ms`); falsy `fps`; invalid `time_ms`; absent `frame`.
- 715-point sweep asserting parity with `floor(t·fps)` (the browser's display semantics).

Verified `model.py` still compiles and no other time→prompt-frame conversion exists (`model.py:832` is a duration→frame-*count*; `model.py:1014` emits a frame's start timestamp back to the FE — both correct as-is).

Jira: https://humansignal.atlassian.net/browse/BROS-1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)