### PR TITLE
fix: BROS-1418: SAM2 returns error 500 when generating Video Vectors in VideoVector+Labels config

### DIFF
--- a/label_studio_ml/examples/segment_anything_video_interactive/control_detect.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/control_detect.py
@@ -1,0 +1,58 @@
+"""Control-tag detection for the SAM2 interactive backend.
+
+Pure config-parsing logic, free of heavy deps (torch/cv2), so it can be
+unit-tested in isolation against a ``label_studio_sdk`` LabelInterface — see
+``test_control_detect.py``. ``model.py`` imports ``detect_control`` from here.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+# Image control tags, in priority order.
+_IMAGE_CONTROLS = ("BitmaskLabels", "RectangleLabels", "PolygonLabels", "VectorLabels")
+
+# Video control tags, in priority order. The self-labeled combined tags come
+# first; `VideoVector` is the standalone (separated) vector control paired with
+# a sibling `<Labels>` tag and is matched last.
+_VIDEO_CONTROLS = ("VideoVectorLabels", "VideoRectangle", "VideoVector")
+
+_CONTROL_TO_TYPE = {
+    "BitmaskLabels": "bitmap",
+    "RectangleLabels": "rectanglelabels",
+    "PolygonLabels": "polygonlabels",
+    "VectorLabels": "vectorlabels",
+    "VideoRectangle": "videorectangle",
+    "VideoVectorLabels": "videovectorlabels",
+    # Standalone `<VideoVector>` (paired with a sibling `<Labels>`) emits the
+    # same type as the combined tag: the result pipeline is identical (a mask
+    # the FE turns into vector geometry) and the FE binds it to the
+    # `VideoVectorLabels` capability. Without this, a VideoVector+Labels config
+    # raised ValueError → HTTP 500 (BROS-1418).
+    "VideoVector": "videovectorlabels",
+}
+
+
+def control_to_type(control: str) -> str:
+    return _CONTROL_TO_TYPE[control]
+
+
+def detect_control(label_interface) -> Tuple[str, str, str, str]:
+    """Return (from_name, to_name, object_type, control_type).
+
+    `object_type` ∈ {'Image', 'Video'}, `control_type` is the xml-lowercased
+    type we'll emit.
+    """
+    for candidate in _IMAGE_CONTROLS:
+        try:
+            from_name, to_name, _ = label_interface.get_first_tag_occurence(candidate, "Image")
+            return from_name, to_name, "Image", control_to_type(candidate)
+        except Exception:
+            pass
+    for candidate in _VIDEO_CONTROLS:
+        try:
+            from_name, to_name, _ = label_interface.get_first_tag_occurence(candidate, "Video")
+            return from_name, to_name, "Video", control_to_type(candidate)
+        except Exception:
+            pass
+    raise ValueError("no supported control tag found in label config")

--- a/label_studio_ml/examples/segment_anything_video_interactive/model.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/model.py
@@ -33,6 +33,7 @@ from label_studio_ml.model import LabelStudioMLBase
 from label_studio_ml.response import ModelResponse
 from label_studio_sdk.label_interface.objects import PredictionValue
 
+from control_detect import control_to_type, detect_control
 from frame_cache import FrameCache
 from mask_encoding import (
     mask_to_bbox_percent,
@@ -308,44 +309,10 @@ def _extract_prompts(context: Dict[str, Any]) -> Dict[str, Any]:
             "box": np.array(box, dtype=np.float32) if box is not None else None}
 
 
-def _detect_control(label_interface) -> Tuple[str, str, str, str]:
-    """Return (from_name, to_name, object_type, control_type).
-
-    `object_type` ∈ {'Image', 'Video'}, `control_type` is the xml-lowercased
-    type we'll emit.
-    """
-    # Image control tags
-    for candidate in ("BitmaskLabels", "RectangleLabels",
-                      "PolygonLabels", "VectorLabels"):
-        try:
-            from_name, to_name, value = label_interface.get_first_tag_occurence(
-                candidate, "Image"
-            )
-            return from_name, to_name, "Image", _control_to_type(candidate)
-        except Exception:
-            pass
-    # Video control tags
-    for candidate, obj_tag in (
-        ("VideoVectorLabels", "Video"),
-        ("VideoRectangle", "Video"),
-    ):
-        try:
-            from_name, to_name, _ = label_interface.get_first_tag_occurence(candidate, obj_tag)
-            return from_name, to_name, "Video", _control_to_type(candidate)
-        except Exception:
-            pass
-    raise ValueError("no supported control tag found in label config")
-
-
-def _control_to_type(control: str) -> str:
-    return {
-        "BitmaskLabels": "bitmap",
-        "RectangleLabels": "rectanglelabels",
-        "PolygonLabels": "polygonlabels",
-        "VectorLabels": "vectorlabels",
-        "VideoRectangle": "videorectangle",
-        "VideoVectorLabels": "videovectorlabels",
-    }[control]
+# Control-tag detection lives in the dependency-free `control_detect` module so
+# it can be unit-tested without torch/cv2 (see test_control_detect.py).
+_detect_control = detect_control
+_control_to_type = control_to_type
 
 
 # ---------------------------------------------------------------------------

--- a/label_studio_ml/examples/segment_anything_video_interactive/test_control_detect.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/test_control_detect.py
@@ -1,0 +1,93 @@
+"""Unit tests for control-tag detection (BROS-1418).
+
+These run without torch/cv2: detection lives in the dependency-free
+``control_detect`` module and is exercised against a real
+``label_studio_sdk`` LabelInterface.
+
+Run with: pytest test_control_detect.py -v
+"""
+
+import pytest
+from label_studio_sdk.label_interface import LabelInterface
+
+from control_detect import detect_control
+
+# Standalone <VideoVector> + separate <Labels> — the config from BROS-1418.
+VIDEOVECTOR_PLUS_LABELS = """
+<View>
+  <VideoVector name="videovec" toName="video" closable="true"/>
+  <Labels name="labels" toName="video">
+    <Label value="Human" background="pink"/>
+    <Label value="Reptile" background="#7CFC00"/>
+  </Labels>
+  <Video name="video" value="$video"/>
+</View>
+""".strip()
+
+# Combined <VideoVectorLabels> — the config that already worked.
+VIDEOVECTORLABELS = """
+<View>
+  <VideoVectorLabels name="videolabels" toName="video">
+    <Label value="Human" background="pink"/>
+  </VideoVectorLabels>
+  <Video name="video" value="$video"/>
+</View>
+""".strip()
+
+VIDEORECTANGLE_PLUS_LABELS = """
+<View>
+  <VideoRectangle name="box" toName="video"/>
+  <Labels name="labels" toName="video">
+    <Label value="Human"/>
+  </Labels>
+  <Video name="video" value="$video"/>
+</View>
+""".strip()
+
+IMAGE_RECTANGLELABELS = """
+<View>
+  <Image name="image" value="$image"/>
+  <RectangleLabels name="tag" toName="image">
+    <Label value="object"/>
+  </RectangleLabels>
+</View>
+""".strip()
+
+NO_SUPPORTED_CONTROL = """
+<View>
+  <Text name="txt" value="$text"/>
+  <Choices name="choice" toName="txt">
+    <Choice value="a"/>
+  </Choices>
+</View>
+""".strip()
+
+
+def test_videovector_plus_labels_is_detected():
+    """Regression for BROS-1418: a standalone <VideoVector> control (paired
+    with a sibling <Labels>) must be detected as a Video control bound to the
+    VideoVectorLabels capability — not raise (which surfaced as HTTP 500).
+    """
+    li = LabelInterface(VIDEOVECTOR_PLUS_LABELS)
+    assert detect_control(li) == ("videovec", "video", "Video", "videovectorlabels")
+
+
+def test_combined_videovectorlabels_still_detected():
+    li = LabelInterface(VIDEOVECTORLABELS)
+    assert detect_control(li) == ("videolabels", "video", "Video", "videovectorlabels")
+
+
+def test_videorectangle_still_detected():
+    li = LabelInterface(VIDEORECTANGLE_PLUS_LABELS)
+    assert detect_control(li) == ("box", "video", "Video", "videorectangle")
+
+
+def test_image_control_still_detected():
+    li = LabelInterface(IMAGE_RECTANGLELABELS)
+    assert detect_control(li) == ("tag", "image", "Image", "rectanglelabels")
+
+
+def test_no_supported_control_raises():
+    li = LabelInterface(NO_SUPPORTED_CONTROL)
+    with pytest.raises(ValueError):
+        detect_control(li)


### PR DESCRIPTION
## Summary

With a `<VideoVector>` + separate `<Labels>` config, interactive SAM2 returned **HTTP 500** on predict.

**Root cause:** the backend resolves the project's control tag via `_detect_control`, which only recognized the **combined** `VideoVectorLabels` (and `VideoRectangle`) video controls. A standalone `<VideoVector name="videovec" toName="video"/>` paired with a sibling `<Labels>` tag matched neither candidate, so `_detect_control` raised `ValueError("no supported control tag found in label config")` → 500.

The frontend half of this was already fixed in **BROS-1232** (`resolve.ts` maps `videovector → VideoVectorLabels` and exempts separated controls in Pattern 2), so the SAM2 UI now appears for this config — and then hit the backend 500. This PR is the backend follow-up.

**Fix:** recognize the standalone `VideoVector` control and map it to the same emit type as the combined tag (`videovectorlabels`). This is correct because:
- The result pipeline always returns a mask (`_mask_response`) that the FE converts into the bound geometry — `control_type` never reshapes the output.
- The FE binds `VideoVector` to the `VideoVectorLabels` capability the backend advertises.
- `get_first_tag_occurence` / `tag.match` compare tag names by **exact** (case-insensitive) equality, so `"VideoVector"` never shadows `"VideoVectorLabels"` (verified in tests).

Detection is extracted into a dependency-free `control_detect` module so it can be unit-tested against a real `LabelInterface` without torch/cv2; `model.py` imports `detect_control` / `control_to_type` from it.

## Test plan

`pytest label_studio_ml/examples/segment_anything_video_interactive/test_control_detect.py -v` — 5 tests against a real `label_studio_sdk` `LabelInterface`:

- **Regression (red→green):** `<VideoVector>` + `<Labels>` resolves to `("videovec", "video", "Video", "videovectorlabels")` — failed before the fix with the exact `ValueError` that surfaced as 500.
- Combined `<VideoVectorLabels>` still resolves (and is **not** shadowed by the new `VideoVector` entry).
- `<VideoRectangle>` + `<Labels>` still resolves.
- Image `RectangleLabels` still resolves.
- A config with no supported control still raises `ValueError`.

Verified `model.py` still compiles; the diff is isolated to control-tag detection (no result-shaping change), so the predict/track pipeline is unchanged for all previously-working configs.

Jira: https://humansignal.atlassian.net/browse/BROS-1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)