### PR TITLE
fix: BROS-1436: SAM2 video interactive — PAT auth, 429 backoff, batched prewarm, model-config fix

### DIFF
--- a/label_studio_ml/examples/segment_anything_video_interactive/README.md
+++ b/label_studio_ml/examples/segment_anything_video_interactive/README.md
@@ -65,14 +65,25 @@ project's control tag.
 | Variable | Default | Description |
 |---|---|---|
 | `DEVICE` | `cuda` | `cuda`, `mps`, or `cpu` |
-| `MODEL_CONFIG` | `sam2_hiera_l.yaml` | SAM2 config name inside the SAM2 repo |
-| `MODEL_CHECKPOINT` | `sam2_hiera_large.pt` | SAM2 checkpoint filename |
+| `MODEL_CONFIG` | `configs/sam2.1/sam2.1_hiera_l.yaml` | SAM2 config name (Hydra path inside the SAM2 repo). Size must match the checkpoint |
+| `MODEL_CHECKPOINT` | `sam2.1_hiera_large.pt` | SAM2 checkpoint filename. For tiny: config `configs/sam2.1/sam2.1_hiera_t.yaml` + checkpoint `sam2.1_hiera_tiny.pt` |
 | `WINDOW_SIZE` | `20` | default prewarm window if client omits `window` |
 | `MAX_CACHED_FRAMES_PER_TASK` | `500` | hard frame-count ceiling per task |
 | `MAX_TASK_CACHE_MB` | `2048` | hard byte ceiling per task |
 | `MAX_GLOBAL_CACHE_MB` | `8192` | hard byte ceiling across all tasks |
 | `TASK_CACHE_TTL_SECONDS` | `1800` | drop idle task caches after this long |
+| `LS_FETCH_RETRY_ATTEMPTS` | `4` | ffmpeg/ffprobe retries on an LS HTTP 429 |
+| `LS_FETCH_RETRY_BASE_DELAY` | `1.0` | base backoff (s) between 429 retries (exponential + jitter) |
+| `LS_FETCH_RETRY_MAX_DELAY` | `30.0` | cap (s) on a single backoff delay |
 | `LABEL_STUDIO_URL` / `LABEL_STUDIO_API_KEY` | — | needed to fetch task assets from LS |
+
+`LABEL_STUDIO_API_KEY` accepts either token type:
+
+- **Legacy token** — sent as-is (`Authorization: Token …`).
+- **Personal Access Token (PAT)** — a JWT refresh token; the backend exchanges
+  it at `LABEL_STUDIO_URL/api/token/refresh` for a short-lived access JWT
+  (`Authorization: Bearer …`), caching and auto-refreshing it before expiry.
+  Requires `LABEL_STUDIO_URL` to be set so the refresh endpoint is reachable.
 
 ## Running locally (no Docker)
 

--- a/label_studio_ml/examples/segment_anything_video_interactive/docker-compose.yml
+++ b/label_studio_ml/examples/segment_anything_video_interactive/docker-compose.yml
@@ -19,9 +19,10 @@ services:
       # Device: cuda | mps | cpu
       - DEVICE=cuda
 
-      # SAM2 model config and checkpoint (resolved inside the segment-anything-2 repo)
-      - MODEL_CONFIG=sam2_hiera_l.yaml
-      - MODEL_CHECKPOINT=sam2_hiera_large.pt
+      # SAM 2.1 model config and checkpoint (resolved inside the segment-anything-2 repo).
+      # Config size must match the checkpoint size; 2.1 configs live under configs/sam2.1/.
+      - MODEL_CONFIG=configs/sam2.1/sam2.1_hiera_l.yaml
+      - MODEL_CHECKPOINT=sam2.1_hiera_large.pt
 
       # Cache & memory caps
       - WINDOW_SIZE=20

--- a/label_studio_ml/examples/segment_anything_video_interactive/ls_auth.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/ls_auth.py
@@ -1,0 +1,125 @@
+"""Label Studio API authentication helpers.
+
+Label Studio Enterprise has two token types and they authenticate differently:
+
+  * Legacy token → an opaque ~40-char string, sent as ``Token <token>``
+    (DRF ``TokenAuthentication``).
+  * Personal Access Token (PAT) → a JWT *refresh* token. It can't be used
+    directly; it must be exchanged at ``/api/token/refresh`` for a short-lived
+    access JWT, which is then sent as ``Bearer <access>``.
+
+``ls_auth_headers`` hides that difference: hand it the LS host + whatever token
+the operator configured, and it returns the right ``Authorization`` header,
+minting and caching access tokens from a PAT as needed.
+
+Dependency-free apart from ``requests`` so it can be unit-tested without torch
+/ cv2 / sam2 (mirrors ``control_detect`` / ``mask_encoding``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import threading
+import time
+from typing import Dict, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Access tokens minted from a PAT, cached per (host, pat) until they near
+# expiry.
+_PAT_LOCK = threading.Lock()
+_PAT_ACCESS_CACHE: Dict[Tuple[str, str], Tuple[str, float]] = {}
+# Refresh this many seconds before the access token's `exp` to avoid racing
+# expiry mid-request.
+_PAT_REFRESH_MARGIN = 60.0
+# If an access token's `exp` can't be read, cache it this long so we don't
+# hammer the refresh endpoint.
+_PAT_FALLBACK_TTL = 300.0
+# Timeout for the token-refresh HTTP call.
+_EXCHANGE_TIMEOUT = 10.0
+
+
+def _looks_like_jwt(token: str) -> bool:
+    """A PAT is a JWT: three base64url segments joined by dots, whose header
+    base64-encodes to a leading ``eyJ``. Legacy LS tokens are opaque strings
+    with no dots, so this cleanly distinguishes the two."""
+    return token.count(".") == 2 and token.startswith("eyJ")
+
+
+def _jwt_exp(token: str) -> Optional[float]:
+    """Best-effort read of a JWT's ``exp`` claim (epoch seconds) WITHOUT
+    verifying the signature — we only need the expiry to schedule a refresh.
+    Returns None if the token can't be parsed."""
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+        exp = payload.get("exp")
+        return float(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+def _exchange_pat(ls_url: str, pat: str) -> Optional[str]:
+    """Exchange a PAT (JWT refresh token) for a short-lived access JWT via
+    LSE's ``/api/token/refresh``. Returns the access token, or None on
+    failure."""
+    try:
+        resp = requests.post(
+            f"{ls_url}/api/token/refresh", json={"refresh": pat},
+            timeout=_EXCHANGE_TIMEOUT,
+        )
+        resp.raise_for_status()
+        access = (resp.json() or {}).get("access")
+        if not access:
+            logger.warning("PAT exchange returned no access token (host=%s)", ls_url)
+            return None
+        return access
+    except Exception as e:
+        logger.warning("PAT exchange failed (host=%s): %s", ls_url, e)
+        return None
+
+
+def _access_token_for_pat(ls_url: str, pat: str) -> Optional[str]:
+    """Return a valid access JWT for ``pat``, minting or refreshing as needed.
+    Cached per (host, pat) and reused until shortly before it expires."""
+    key = (ls_url, pat)
+    now = time.time()
+    with _PAT_LOCK:
+        cached = _PAT_ACCESS_CACHE.get(key)
+        if cached is not None and now < cached[1] - _PAT_REFRESH_MARGIN:
+            return cached[0]
+    # Exchange outside the lock (network I/O); a rare concurrent double-exchange
+    # is harmless — last writer wins and both tokens are valid.
+    access = _exchange_pat(ls_url, pat)
+    if access is None:
+        return None
+    exp = _jwt_exp(access)
+    expires_at = exp if exp is not None else now + _PAT_FALLBACK_TTL
+    with _PAT_LOCK:
+        _PAT_ACCESS_CACHE[key] = (access, expires_at)
+    return access
+
+
+def ls_auth_headers(ls_url: Optional[str], token: Optional[str]) -> Optional[Dict[str, str]]:
+    """Build the ``Authorization`` header for an LS-hosted asset fetch.
+
+    * Legacy token → ``Token <token>``.
+    * PAT (JWT) → exchanged for a short-lived access JWT, sent as
+      ``Bearer <access>``. Falls back to ``Token <pat>`` if the exchange fails
+      or the LS host is unknown, so legacy deployments still behave as before.
+
+    Returns None when no token is configured.
+    """
+    if not token:
+        return None
+    if ls_url and _looks_like_jwt(token):
+        access = _access_token_for_pat(ls_url, token)
+        if access:
+            return {"Authorization": f"Bearer {access}"}
+        logger.warning("PAT exchange unavailable — falling back to Token scheme")
+    return {"Authorization": f"Token {token}"}

--- a/label_studio_ml/examples/segment_anything_video_interactive/model.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/model.py
@@ -36,6 +36,7 @@ from label_studio_sdk.label_interface.objects import PredictionValue
 from control_detect import control_to_type, detect_control
 from frame_cache import FrameCache
 from frame_resolve import resolve_frame_index
+from ls_auth import ls_auth_headers
 from mask_encoding import (
     mask_to_bbox_percent,
     mask_to_bitmap_png_base64,
@@ -47,8 +48,11 @@ logger = logging.getLogger(__name__)
 
 DEVICE = os.getenv("DEVICE", "cuda")
 SEGMENT_ANYTHING_2_REPO_PATH = os.getenv("SEGMENT_ANYTHING_2_REPO_PATH", "segment-anything-2")
-MODEL_CONFIG = os.getenv("MODEL_CONFIG", "sam2_hiera_l.yaml")
-MODEL_CHECKPOINT = os.getenv("MODEL_CHECKPOINT", "sam2_hiera_large.pt")
+# SAM 2.1 by default — `download_ckpts.sh` now fetches only sam2.1_* weights,
+# and the matching configs live under the `configs/sam2.1/` Hydra group. Config
+# size must match the checkpoint size.
+MODEL_CONFIG = os.getenv("MODEL_CONFIG", "configs/sam2.1/sam2.1_hiera_l.yaml")
+MODEL_CHECKPOINT = os.getenv("MODEL_CHECKPOINT", "sam2.1_hiera_large.pt")
 WINDOW_SIZE = int(os.getenv("WINDOW_SIZE", "20"))
 MAX_FRAMES_TO_TRACK = int(os.getenv("MAX_FRAMES_TO_TRACK", "300"))
 
@@ -529,7 +533,7 @@ class SamVideoInteractive(LabelStudioMLBase):
                 ],
                 "model_info": {
                     "name": "SAM2",
-                    "version": os.getenv("MODEL_CHECKPOINT", "sam2_hiera_large.pt"),
+                    "version": MODEL_CHECKPOINT,
                 },
             },
         }])
@@ -642,9 +646,19 @@ class SamVideoInteractive(LabelStudioMLBase):
 
         if event == "prewarm":
             frame_range = self._window_range(frame, window, direction, video.frame_count)
-            cached, pending = FRAME_CACHE.submit(
-                task_id, frame_range, lambda idx: self._encode_frame(task_id, idx)
-            )
+            # Fetch the whole window in ONE ffmpeg pass (one HTTP request to LS)
+            # rather than one request per frame, which trips LS's rate limit.
+            # The encode step pulls decoded frames from this buffer, falling
+            # back to a per-frame read only for any the prefetch missed.
+            prefetched = self._prefetch_window(video, frame_range)
+
+            def _encode(idx, _video=video, _frames=prefetched):
+                bgr = _frames.get(idx)
+                if bgr is None:
+                    bgr = _video.read_frame(idx)
+                return self._encode_bgr(bgr)
+
+            cached, pending = FRAME_CACHE.submit(task_id, frame_range, _encode)
             return PredictionValue(result=[{
                 "value": {"status": "ok", "cached": cached, "pending": pending,
                           "frame_count": video.frame_count},
@@ -744,7 +758,9 @@ class SamVideoInteractive(LabelStudioMLBase):
         api_key = api_key_opt or ""
 
         def _auth_headers():
-            return {"Authorization": f"Token {api_key}"} if api_key else None
+            # Handles both legacy tokens (`Token <key>`) and Personal Access
+            # Tokens (exchanged for a short-lived `Bearer <access>` JWT).
+            return ls_auth_headers(ls_url, api_key)
 
         def _points_at_ls(url: str) -> bool:
             if not ls_url:
@@ -1074,9 +1090,14 @@ class SamVideoInteractive(LabelStudioMLBase):
         video = VIDEOS._handles.get(task_id)
         if video is None:
             raise RuntimeError(f"no video handle for task {task_id}")
-        frame_bgr = video.read_frame(frame_idx)
-        rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
+        return self._encode_bgr(video.read_frame(frame_idx))
 
+    def _encode_bgr(self, frame_bgr):
+        """Encode an already-decoded BGR frame into a SAM2 image embedding.
+        Split out from `_encode_frame` so prewarm can fetch a whole window in
+        one ffmpeg pass (one HTTP request) and feed the frames in here, instead
+        of one network read per frame (which trips LS rate limits)."""
+        rgb = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2RGB)
         image_predictor = make_image_predictor()
         image_predictor.set_image(rgb)
         return {
@@ -1084,6 +1105,25 @@ class SamVideoInteractive(LabelStudioMLBase):
             "original_size": image_predictor._orig_hw,
             "is_image_set": True,
         }
+
+    def _prefetch_window(self, video, frame_range: List[int]) -> Dict[int, Any]:
+        """Fetch a contiguous frame window in a single ffmpeg pass to collapse
+        one-HTTP-request-per-frame into one request for the whole window.
+
+        Best-effort: returns {frame_idx: bgr_frame}; on any failure returns the
+        frames it managed to get (possibly empty) and the encode step falls back
+        to per-frame reads for the rest.
+        """
+        if not frame_range:
+            return {}
+        start = min(frame_range)
+        count = max(frame_range) - start + 1
+        try:
+            frames = video.read_frame_range(start, count)
+        except Exception as e:
+            logger.warning("window prefetch failed (%s); falling back to per-frame", e)
+            return {}
+        return {start + i: f for i, f in enumerate(frames)}
 
     def _window_range(self, frame: int, window: int, direction: str, frame_count: int):
         if direction == "backward":

--- a/label_studio_ml/examples/segment_anything_video_interactive/requirements-base.txt
+++ b/label_studio_ml/examples/segment_anything_video_interactive/requirements-base.txt
@@ -1,2 +1,3 @@
 gunicorn==22.0.0
+requests
 label-studio-ml @ git+https://github.com/HumanSignal/label-studio-ml-backend.git

--- a/label_studio_ml/examples/segment_anything_video_interactive/test_ls_auth.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/test_ls_auth.py
@@ -1,0 +1,135 @@
+"""Unit tests for LS API auth header building (legacy token vs PAT).
+
+These run without torch/cv2: the auth logic lives in the dependency-free
+``ls_auth`` module. ``requests`` is stubbed so no network is touched.
+
+Run with: pytest test_ls_auth.py -v
+"""
+
+import base64
+import json
+import time
+from unittest import mock
+
+import pytest
+
+import ls_auth
+
+
+def _make_jwt(exp=None, token_type="refresh"):
+    """Build a syntactically valid (unsigned) JWT for testing detection and
+    `exp` parsing. Signature is a dummy — nothing here verifies it."""
+    def b64(obj):
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    header = b64({"alg": "HS256", "typ": "JWT"})
+    payload_obj = {"token_type": token_type, "user_id": "1"}
+    if exp is not None:
+        payload_obj["exp"] = exp
+    payload = b64(payload_obj)
+    return f"{header}.{payload}.{'sig'}"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Each test starts with an empty PAT access-token cache."""
+    ls_auth._PAT_ACCESS_CACHE.clear()
+    yield
+    ls_auth._PAT_ACCESS_CACHE.clear()
+
+
+# --- token-type detection -------------------------------------------------
+
+def test_legacy_token_not_detected_as_jwt():
+    assert ls_auth._looks_like_jwt("0123456789abcdef0123456789abcdef01234567") is False
+
+
+def test_pat_detected_as_jwt():
+    assert ls_auth._looks_like_jwt(_make_jwt(exp=9999999999)) is True
+
+
+def test_jwt_exp_parsed():
+    assert ls_auth._jwt_exp(_make_jwt(exp=123456)) == 123456.0
+
+
+def test_jwt_exp_missing_returns_none():
+    assert ls_auth._jwt_exp(_make_jwt(exp=None)) is None
+
+
+def test_jwt_exp_garbage_returns_none():
+    assert ls_auth._jwt_exp("not-a-jwt") is None
+
+
+# --- header building ------------------------------------------------------
+
+def test_no_token_returns_none():
+    assert ls_auth.ls_auth_headers("http://ls", "") is None
+    assert ls_auth.ls_auth_headers("http://ls", None) is None
+
+
+def test_legacy_token_uses_token_scheme():
+    headers = ls_auth.ls_auth_headers("http://ls", "legacytoken123")
+    assert headers == {"Authorization": "Token legacytoken123"}
+
+
+def test_pat_is_exchanged_for_bearer():
+    pat = _make_jwt(exp=9999999999)
+    access = _make_jwt(exp=int(time.time()) + 3600)
+    resp = mock.Mock()
+    resp.json.return_value = {"access": access}
+    resp.raise_for_status.return_value = None
+    with mock.patch.object(ls_auth.requests, "post", return_value=resp) as post:
+        headers = ls_auth.ls_auth_headers("http://ls", pat)
+    assert headers == {"Authorization": f"Bearer {access}"}
+    post.assert_called_once_with(
+        "http://ls/api/token/refresh", json={"refresh": pat},
+        timeout=ls_auth._EXCHANGE_TIMEOUT,
+    )
+
+
+def test_pat_access_token_is_cached():
+    pat = _make_jwt(exp=9999999999)
+    access = _make_jwt(exp=int(time.time()) + 3600)
+    resp = mock.Mock()
+    resp.json.return_value = {"access": access}
+    resp.raise_for_status.return_value = None
+    with mock.patch.object(ls_auth.requests, "post", return_value=resp) as post:
+        ls_auth.ls_auth_headers("http://ls", pat)
+        ls_auth.ls_auth_headers("http://ls", pat)  # second call hits cache
+    post.assert_called_once()  # only one network exchange
+
+
+def test_expired_cached_access_token_is_refreshed():
+    pat = _make_jwt(exp=9999999999)
+    # Access token already past the refresh margin → must re-exchange.
+    stale = _make_jwt(exp=int(time.time()) + 10)
+    fresh = _make_jwt(exp=int(time.time()) + 3600)
+    responses = [mock.Mock(), mock.Mock()]
+    responses[0].json.return_value = {"access": stale}
+    responses[1].json.return_value = {"access": fresh}
+    for r in responses:
+        r.raise_for_status.return_value = None
+    with mock.patch.object(ls_auth.requests, "post", side_effect=responses) as post:
+        first = ls_auth.ls_auth_headers("http://ls", pat)
+        second = ls_auth.ls_auth_headers("http://ls", pat)
+    assert first == {"Authorization": f"Bearer {stale}"}
+    assert second == {"Authorization": f"Bearer {fresh}"}
+    assert post.call_count == 2
+
+
+def test_pat_falls_back_to_token_when_exchange_fails():
+    pat = _make_jwt(exp=9999999999)
+    with mock.patch.object(ls_auth.requests, "post", side_effect=Exception("boom")):
+        headers = ls_auth.ls_auth_headers("http://ls", pat)
+    # Degrade to legacy scheme rather than dropping auth entirely.
+    assert headers == {"Authorization": f"Token {pat}"}
+
+
+def test_pat_without_host_falls_back_to_token():
+    pat = _make_jwt(exp=9999999999)
+    # No LS host → can't reach the refresh endpoint; don't attempt exchange.
+    with mock.patch.object(ls_auth.requests, "post") as post:
+        headers = ls_auth.ls_auth_headers("", pat)
+    post.assert_not_called()
+    assert headers == {"Authorization": f"Token {pat}"}

--- a/label_studio_ml/examples/segment_anything_video_interactive/test_video_fetch_retry.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/test_video_fetch_retry.py
@@ -1,0 +1,95 @@
+"""Unit tests for HTTP-429 detection and ffmpeg backoff in video_state.
+
+`video_state` imports cv2/numpy at module load but only uses them inside
+methods, so we stub them in sys.modules to keep this test dependency-free
+(same spirit as test_control_detect / test_ls_auth). subprocess + time.sleep
+are mocked so no real process runs and no real waiting happens.
+
+Run with: pytest test_video_fetch_retry.py -v
+"""
+
+import sys
+import types
+from unittest import mock
+
+# --- stub heavy deps before importing the module under test ---------------
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+import video_state  # noqa: E402
+
+
+def _proc(returncode, stderr=b""):
+    return types.SimpleNamespace(returncode=returncode, stderr=stderr, stdout=b"")
+
+
+# --- 429 detection --------------------------------------------------------
+
+def test_detects_numeric_429():
+    assert video_state._is_rate_limited(b"Server returned 429 Too Many Requests") is True
+
+
+def test_detects_text_too_many_requests():
+    assert video_state._is_rate_limited("HTTP error: too many requests") is True
+
+
+def test_non_429_error_not_flagged():
+    assert video_state._is_rate_limited(b"Server returned 404 Not Found") is False
+
+
+def test_none_stderr_not_flagged():
+    assert video_state._is_rate_limited(None) is False
+
+
+# --- backoff behavior -----------------------------------------------------
+
+def test_success_runs_once():
+    with mock.patch.object(video_state.subprocess, "run", return_value=_proc(0)) as run, \
+         mock.patch.object(video_state.time, "sleep") as sleep:
+        result = video_state._run_with_429_backoff(["ffmpeg"], timeout=10)
+    assert result.returncode == 0
+    run.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_non_retryable_failure_runs_once():
+    fail = _proc(1, b"Server returned 404 Not Found")
+    with mock.patch.object(video_state.subprocess, "run", return_value=fail) as run, \
+         mock.patch.object(video_state.time, "sleep") as sleep:
+        result = video_state._run_with_429_backoff(["ffmpeg"], timeout=10)
+    assert result.returncode == 1
+    run.assert_called_once()  # 404 is not retried
+    sleep.assert_not_called()
+
+
+def test_retries_then_succeeds_on_429():
+    seq = [_proc(1, b"429 Too Many Requests"), _proc(1, b"429 Too Many Requests"), _proc(0)]
+    with mock.patch.object(video_state.subprocess, "run", side_effect=seq) as run, \
+         mock.patch.object(video_state.time, "sleep") as sleep:
+        result = video_state._run_with_429_backoff(["ffmpeg"], timeout=10)
+    assert result.returncode == 0
+    assert run.call_count == 3
+    assert sleep.call_count == 2  # backoff before each retry, not after success
+
+
+def test_gives_up_after_max_attempts():
+    fail = _proc(1, b"429 Too Many Requests")
+    with mock.patch.object(video_state, "_FETCH_RETRY_ATTEMPTS", 3), \
+         mock.patch.object(video_state.subprocess, "run", return_value=fail) as run, \
+         mock.patch.object(video_state.time, "sleep") as sleep:
+        result = video_state._run_with_429_backoff(["ffmpeg"], timeout=10)
+    assert result.returncode == 1  # last 429 returned; caller raises with stderr
+    assert run.call_count == 3
+    assert sleep.call_count == 2  # no sleep after the final failed attempt
+
+
+def test_backoff_delay_is_capped():
+    fail = _proc(1, b"429 Too Many Requests")
+    delays = []
+    with mock.patch.object(video_state, "_FETCH_RETRY_ATTEMPTS", 8), \
+         mock.patch.object(video_state, "_FETCH_RETRY_MAX_DELAY", 5.0), \
+         mock.patch.object(video_state.subprocess, "run", return_value=fail), \
+         mock.patch.object(video_state.time, "sleep", side_effect=delays.append):
+        video_state._run_with_429_backoff(["ffmpeg"], timeout=10)
+    assert delays  # backed off at least once
+    assert max(delays) <= 5.0  # never exceeds the configured cap

--- a/label_studio_ml/examples/segment_anything_video_interactive/video_state.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/video_state.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import random
 import subprocess
 import threading
+import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -21,6 +23,47 @@ import cv2
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+# Streaming frames from LS issues one HTTP request per ffmpeg/ffprobe call.
+# Under a prewarm burst that can trip LS's rate limit (HTTP 429). ffmpeg
+# doesn't surface `Retry-After`, so we detect the 429 in its stderr and retry
+# with exponential backoff + jitter.
+_FETCH_RETRY_ATTEMPTS = int(os.getenv("LS_FETCH_RETRY_ATTEMPTS", "4"))
+_FETCH_RETRY_BASE_DELAY = float(os.getenv("LS_FETCH_RETRY_BASE_DELAY", "1.0"))
+_FETCH_RETRY_MAX_DELAY = float(os.getenv("LS_FETCH_RETRY_MAX_DELAY", "30.0"))
+
+
+def _is_rate_limited(stderr) -> bool:
+    """True if ffmpeg/ffprobe stderr indicates an HTTP 429 from the server."""
+    if stderr is None:
+        return False
+    text = stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else str(stderr)
+    text = text.lower()
+    return "429" in text or "too many requests" in text
+
+
+def _run_with_429_backoff(cmd: List[str], *, timeout: int, text: bool = False):
+    """Run an ffmpeg/ffprobe command, retrying on HTTP 429 with exponential
+    backoff + jitter. Returns the final CompletedProcess (success, a
+    non-retryable failure, or the last 429 after exhausting attempts) — the
+    caller inspects returncode as before."""
+    result = None
+    for attempt in range(_FETCH_RETRY_ATTEMPTS):
+        result = subprocess.run(cmd, capture_output=True, text=text, timeout=timeout)
+        if result.returncode == 0 or not _is_rate_limited(result.stderr):
+            return result
+        if attempt == _FETCH_RETRY_ATTEMPTS - 1:
+            break
+        delay = min(
+            _FETCH_RETRY_BASE_DELAY * (2 ** attempt) + random.uniform(0, 0.5),
+            _FETCH_RETRY_MAX_DELAY,
+        )
+        logger.warning(
+            "LS rate-limited (HTTP 429); backing off %.1fs (attempt %d/%d)",
+            delay, attempt + 1, _FETCH_RETRY_ATTEMPTS,
+        )
+        time.sleep(delay)
+    return result
 
 
 def _validate_probe_source(source: str) -> str:
@@ -57,7 +100,7 @@ def _probe_video(source: str, headers: Optional[Dict[str, str]] = None) -> dict:
     cmd.extend(["--", source])
     source_kind = "url" if source.startswith("http://") or source.startswith("https://") else "local"
     logger.info("ffprobe started (source_kind=%s)", source_kind)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    result = _run_with_429_backoff(cmd, timeout=30, text=True)
     if result.returncode != 0:
         logger.error("ffprobe failed: returncode=%s stderr=%s stdout=%s",
                       result.returncode, result.stderr[:500], result.stdout[:200])
@@ -153,7 +196,7 @@ class VideoHandle:
                "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "bgr24",
                "pipe:1"]
         )
-        result = subprocess.run(cmd, capture_output=True, timeout=30)
+        result = _run_with_429_backoff(cmd, timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"ffmpeg frame read failed: {result.stderr[:300]}")
         expected = self.width * self.height * 3
@@ -174,7 +217,7 @@ class VideoHandle:
                "-frames:v", str(count), "-f", "rawvideo", "-pix_fmt", "bgr24",
                "pipe:1"]
         )
-        result = subprocess.run(cmd, capture_output=True, timeout=120)
+        result = _run_with_429_backoff(cmd, timeout=120)
         if result.returncode != 0:
             raise RuntimeError(f"ffmpeg range read failed: {result.stderr[:300]}")
         frame_bytes = self.width * self.height * 3
@@ -221,7 +264,7 @@ class VideoHandle:
                "-frames:v", str(count), "-q:v", "2",
                "-start_number", "0", pattern]
         )
-        result = subprocess.run(cmd, capture_output=True, timeout=120)
+        result = _run_with_429_backoff(cmd, timeout=120)
         if result.returncode != 0:
             raise RuntimeError(f"ffmpeg JPEG extraction failed: {result.stderr[:300]}")
         written = len([f for f in os.listdir(output_dir) if f.endswith(".jpg")])


### PR DESCRIPTION
## Summary

Hardens the `segment_anything_video_interactive` ML backend so it actually connects to and streams from LSE in real deployments. Four related fixes:

### 1. Personal Access Token (PAT) auth
The backend only sent `Authorization: Token <key>`, which works with **legacy** tokens but not **Personal Access Tokens** (JWT refresh tokens) — so PAT-configured instances failed auth.
- New dependency-free `ls_auth.py`: detects token type, exchanges a PAT at `/api/token/refresh` for a short-lived access JWT, sends it as `Bearer …`, and caches/refreshes it before expiry (thread-safe, single-flight-ish).
- Falls back to the legacy `Token` scheme if exchange fails or the LS host is unknown, so existing deployments are unaffected.

### 2. HTTP 429 backoff on asset fetches
Streaming frames issues one ffmpeg/ffprobe HTTP request per call; under load LSE returns 429.
- `video_state.py` now detects 429 in ffmpeg/ffprobe stderr and retries with exponential backoff + jitter (capped). Non-429 failures are not retried.
- Tunable via `LS_FETCH_RETRY_ATTEMPTS` / `LS_FETCH_RETRY_BASE_DELAY` / `LS_FETCH_RETRY_MAX_DELAY`.

### 3. Batched prewarm fetch
Prewarm previously read each frame with its own ffmpeg HTTP request (a 20-frame window = ~20 requests), which is what tripped the rate limit.
- Prewarm now fetches the whole contiguous window in **one** ffmpeg pass (`_prefetch_window`) and feeds decoded frames into the per-frame SAM2 encode (`_encode_bgr`), falling back to a single-frame read only for any miss.

### 4. SAM 2.1 model-config resolution
`download_ckpts.sh` now fetches only `sam2.1_*` weights, but defaults still pointed at the old `sam2_hiera_l.yaml` / `sam2_hiera_large.pt`, causing `load_state_dict` mismatches (large config + tiny weights) and Hydra "config not found".
- Defaults updated to `configs/sam2.1/sam2.1_hiera_l.yaml` / `sam2.1_hiera_large.pt` in `model.py` and `docker-compose.yml`; README documents the 2.1 naming and the tiny pairing.

## Tests
- `test_ls_auth.py` (12) — token detection, exp parsing, PAT exchange, caching, refresh-on-expiry, fallbacks.
- `test_video_fetch_retry.py` (9) — 429 detection, retry-then-succeed, give-up, no-retry on non-429, delay cap.
- Both run without torch/cv2 (heavy deps stubbed), matching the existing `test_control_detect.py` style. **21/21 pass.**

## Notes
- `requests` added to `requirements-base.txt` (now a direct import).
- Per-frame reads in the `predict`/`track` paths are unchanged (single frames, not bursts) — a candidate for follow-up batching if heavy tracking still brushes the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)