### PR TITLE
fix(ppocr): load OCR pipeline once per process, not per request

### DIFF
--- a/label_studio_ml/examples/ppocr/model.py
+++ b/label_studio_ml/examples/ppocr/model.py
@@ -85,6 +85,8 @@ class PPOCR(LabelStudioMLBase):
         'th',  # Thai
     }
 
+    # Process-wide pipeline cache. The API creates a new PPOCR instance per /predict
+    # request, so this must be stored on the class (not the instance) to load once.
     _pipeline = None
 
     def _lazy_init(self):
@@ -190,7 +192,8 @@ class PPOCR(LabelStudioMLBase):
             pp_option.run_mode = 'paddle'
             logger.info(f"  Run mode: paddle (GPU)")
 
-        self._pipeline = create_pipeline(config=config, device=self.DEVICE, pp_option=pp_option)
+        # Cache on the class so every per-request instance reuses the same pipeline.
+        PPOCR._pipeline = create_pipeline(config=config, device=self.DEVICE, pp_option=pp_option)
         logger.info(f"{version_tag} pipeline initialized successfully")
 
     def setup(self):


### PR DESCRIPTION
## What

The PP-OCR example rebuilt the PaddleX pipeline (and reloaded the model
weights) on **every** `/predict` request. This caches it once per worker process.

## Why

The ML backend API creates a fresh model instance for each request:

```python
# label_studio_ml/api.py
model = MODEL_CLASS(project_id=project_id, label_config=label_config)
response = model.predict(tasks, ...)
```

`PPOCR._lazy_init()` guards on the class attribute `_pipeline = None` but assigned the built pipeline to `self._pipeline`, which creates an
*instance* attribute and leaves the class attribute `None`. So every new
per-request instance saw `None` and re-ran `create_pipeline(...)`,
reloading the detection + recognition weights each time — a large,
avoidable latency on each prediction.

## Fix

Assign the pipeline to `PPOCR._pipeline` (class attribute) so it is built
once per worker process and reused by all subsequent request instances.

