### PR TITLE
fix: BROS-1452: Handle SAM2 video auth fallback for LS assets

### DIFF
--- a/label_studio_ml/examples/segment_anything_video_interactive/ls_auth.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/ls_auth.py
@@ -1,125 +1,112 @@
-"""Label Studio API authentication helpers.
+"""Label Studio API authentication helpers for streaming video assets.
 
-Label Studio Enterprise has two token types and they authenticate differently:
+Most ML backends can delegate asset auth entirely to ``get_local_path()``. This
+backend is different because ffprobe/ffmpeg stream LS-hosted videos directly, so
+we need headers outside of the SDK downloader. Keep the token semantics aligned
+with the SDK instead of reimplementing JWT parsing / refresh logic here:
 
-  * Legacy token → an opaque ~40-char string, sent as ``Token <token>``
-    (DRF ``TokenAuthentication``).
-  * Personal Access Token (PAT) → a JWT *refresh* token. It can't be used
-    directly; it must be exchanged at ``/api/token/refresh`` for a short-lived
-    access JWT, which is then sent as ``Bearer <access>``.
-
-``ls_auth_headers`` hides that difference: hand it the LS host + whatever token
-the operator configured, and it returns the right ``Authorization`` header,
-minting and caching access tokens from a PAT as needed.
-
-Dependency-free apart from ``requests`` so it can be unit-tested without torch
-/ cv2 / sam2 (mirrors ``control_detect`` / ``mask_encoding``).
+* ``TokensClientExt.resolve_x_api_key_header_value`` normalizes refresh JWTs
+  (PATs) into access JWTs and leaves legacy/access tokens unchanged.
+* ``io._build_headers`` applies the same Authorization scheme selection used by
+  ``get_local_path`` (JWT => Bearer, opaque token => Token) and only attaches it
+  for matching LS hosts.
 """
 
 from __future__ import annotations
 
-import base64
-import json
 import logging
 import threading
-import time
 from typing import Dict, Optional, Tuple
 
-import requests
+from label_studio_sdk import LabelStudio
+from label_studio_sdk._extensions.label_studio_tools.core.utils.io import _build_headers
+
+from url_auth import should_attach_ls_auth
 
 logger = logging.getLogger(__name__)
 
-# Access tokens minted from a PAT, cached per (host, pat) until they near
-# expiry.
-_PAT_LOCK = threading.Lock()
-_PAT_ACCESS_CACHE: Dict[Tuple[str, str], Tuple[str, float]] = {}
-# Refresh this many seconds before the access token's `exp` to avoid racing
-# expiry mid-request.
-_PAT_REFRESH_MARGIN = 60.0
-# If an access token's `exp` can't be read, cache it this long so we don't
-# hammer the refresh endpoint.
-_PAT_FALLBACK_TTL = 300.0
-# Timeout for the token-refresh HTTP call.
-_EXCHANGE_TIMEOUT = 10.0
+_CLIENT_LOCK = threading.Lock()
+_SDK_CLIENT_CACHE: Dict[Tuple[str, str], LabelStudio] = {}
 
 
-def _looks_like_jwt(token: str) -> bool:
-    """A PAT is a JWT: three base64url segments joined by dots, whose header
-    base64-encodes to a leading ``eyJ``. Legacy LS tokens are opaque strings
-    with no dots, so this cleanly distinguishes the two."""
-    return token.count(".") == 2 and token.startswith("eyJ")
+def _sdk_client(ls_url: Optional[str], token: Optional[str]) -> Optional[LabelStudio]:
+    """Return a cached SDK client so token refresh/caching stays inside SDK.
 
-
-def _jwt_exp(token: str) -> Optional[float]:
-    """Best-effort read of a JWT's ``exp`` claim (epoch seconds) WITHOUT
-    verifying the signature — we only need the expiry to schedule a refresh.
-    Returns None if the token can't be parsed."""
-    try:
-        payload_b64 = token.split(".")[1]
-        payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        exp = payload.get("exp")
-        return float(exp) if exp is not None else None
-    except Exception:
+    The client wrapper owns ``TokensClientExt``; using it here means the
+    streaming path shares the SDK's JWT token-type detection, refresh exchange,
+    expiry handling, and locking instead of duplicating that code locally.
+    """
+    if not ls_url or not token:
         return None
+    key = (ls_url.rstrip("/"), token)
+    with _CLIENT_LOCK:
+        client = _SDK_CLIENT_CACHE.get(key)
+        if client is None:
+            client = LabelStudio(base_url=key[0], api_key=token)
+            _SDK_CLIENT_CACHE[key] = client
+        return client
 
 
-def _exchange_pat(ls_url: str, pat: str) -> Optional[str]:
-    """Exchange a PAT (JWT refresh token) for a short-lived access JWT via
-    LSE's ``/api/token/refresh``. Returns the access token, or None on
-    failure."""
+def _resolve_token_with_sdk(ls_url: Optional[str], token: str) -> str:
+    """Normalize a token using the SDK token client when available.
+
+    Legacy tokens and access JWTs are returned unchanged. Refresh JWTs are
+    exchanged for access JWTs by the SDK. If SDK normalization is unavailable or
+    fails, return the original token so callers preserve the previous fallback
+    behavior and surface the eventual 401 from LS rather than hiding it here.
+    """
     try:
-        resp = requests.post(
-            f"{ls_url}/api/token/refresh", json={"refresh": pat},
-            timeout=_EXCHANGE_TIMEOUT,
-        )
-        resp.raise_for_status()
-        access = (resp.json() or {}).get("access")
-        if not access:
-            logger.warning("PAT exchange returned no access token (host=%s)", ls_url)
-            return None
-        return access
+        client = _sdk_client(ls_url, token)
+        if client is None:
+            return token
+        tokens_client = client._client_wrapper._tokens_client
+        return tokens_client.resolve_x_api_key_header_value(token)
     except Exception as e:
-        logger.warning("PAT exchange failed (host=%s): %s", ls_url, e)
-        return None
+        logger.warning("SDK token normalization failed (host=%s): %s", ls_url, e)
+        return token
 
 
-def _access_token_for_pat(ls_url: str, pat: str) -> Optional[str]:
-    """Return a valid access JWT for ``pat``, minting or refreshing as needed.
-    Cached per (host, pat) and reused until shortly before it expires."""
-    key = (ls_url, pat)
-    now = time.time()
-    with _PAT_LOCK:
-        cached = _PAT_ACCESS_CACHE.get(key)
-        if cached is not None and now < cached[1] - _PAT_REFRESH_MARGIN:
-            return cached[0]
-    # Exchange outside the lock (network I/O); a rare concurrent double-exchange
-    # is harmless — last writer wins and both tokens are valid.
-    access = _exchange_pat(ls_url, pat)
-    if access is None:
-        return None
-    exp = _jwt_exp(access)
-    expires_at = exp if exp is not None else now + _PAT_FALLBACK_TTL
-    with _PAT_LOCK:
-        _PAT_ACCESS_CACHE[key] = (access, expires_at)
-    return access
+def ls_token_for_sdk(ls_url: Optional[str], token: Optional[str]) -> Optional[str]:
+    """Return the token value to hand to ``get_local_path``.
 
-
-def ls_auth_headers(ls_url: Optional[str], token: Optional[str]) -> Optional[Dict[str, str]]:
-    """Build the ``Authorization`` header for an LS-hosted asset fetch.
-
-    * Legacy token → ``Token <token>``.
-    * PAT (JWT) → exchanged for a short-lived access JWT, sent as
-      ``Bearer <access>``. Falls back to ``Token <pat>`` if the exchange fails
-      or the LS host is unknown, so legacy deployments still behave as before.
-
-    Returns None when no token is configured.
+    ``get_local_path`` already knows how to choose ``Token`` vs ``Bearer`` for a
+    token value, but older downloader code does not exchange refresh JWTs first.
+    Passing the SDK-normalized value lets download fallback and streaming use the
+    same credential.
     """
     if not token:
         return None
-    if ls_url and _looks_like_jwt(token):
-        access = _access_token_for_pat(ls_url, token)
-        if access:
-            return {"Authorization": f"Bearer {access}"}
-        logger.warning("PAT exchange unavailable — falling back to Token scheme")
-    return {"Authorization": f"Token {token}"}
+    return _resolve_token_with_sdk(ls_url, token.strip())
+
+
+def ls_auth_headers(
+    ls_url: Optional[str],
+    token: Optional[str],
+    target_url: Optional[str] = None,
+) -> Optional[Dict[str, str]]:
+    """Build SDK-compatible auth headers for an LS-hosted streaming URL.
+
+    ``target_url`` is optional for existing callers, but should be supplied for
+    streaming so SDK header construction can enforce the same host match as
+    ``get_local_path``. Host/token leakage prevention still lives in
+    ``url_auth.should_attach_ls_auth`` before this helper is called.
+    """
+    wire_token = ls_token_for_sdk(ls_url, token)
+    if not wire_token:
+        return None
+
+    if ls_url and target_url and not should_attach_ls_auth(target_url, ls_url, True):
+        headers = _build_headers(target_url, ls_url, wire_token)
+        return headers or None
+
+    # `should_attach_ls_auth` is intentionally scheme/port-insensitive so the
+    # operator can configure `LABEL_STUDIO_URL=http://host:80` while LS returns
+    # `https://host/...` asset URLs. The SDK's `_build_headers` uses exact
+    # netloc equality, so after our guard says the target is safe, build against
+    # `ls_url` itself to reuse the SDK's Token-vs-Bearer choice without losing
+    # auth on benign scheme/port differences.
+    if ls_url:
+        headers = _build_headers(ls_url, ls_url, wire_token)
+        return headers or None
+
+    return None

--- a/label_studio_ml/examples/segment_anything_video_interactive/model.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/model.py
@@ -36,7 +36,7 @@ from label_studio_sdk.label_interface.objects import PredictionValue
 from control_detect import control_to_type, detect_control
 from frame_cache import FrameCache
 from frame_resolve import resolve_frame_index
-from ls_auth import ls_auth_headers
+from ls_auth import ls_auth_headers, ls_token_for_sdk
 from url_auth import should_attach_ls_auth
 from mask_encoding import (
     mask_to_bbox_percent,
@@ -560,7 +560,10 @@ class SamVideoInteractive(LabelStudioMLBase):
         image_url = self._image_url_from_task(task, to_name)
         ls_host, ls_token = self._ls_host_token()
         local_path = self.get_local_path(
-            image_url, task_id=task_id, ls_host=ls_host, ls_access_token=ls_token,
+            image_url,
+            task_id=task_id,
+            ls_host=ls_host,
+            ls_access_token=ls_token_for_sdk(ls_host, ls_token),
         )
 
         bgr = cv2.imread(local_path)
@@ -718,22 +721,31 @@ class SamVideoInteractive(LabelStudioMLBase):
         return self._mask_response(mask, w, h, from_name, to_name)
 
     def _ls_host_token(self) -> Tuple[Optional[str], Optional[str]]:
-        """Return (ls_host, ls_token) using env vars first, then the cache
-        populated from `/setup`. Either may be None; callers pass them into
-        `self.get_local_path(ls_host=..., ls_access_token=...)` which lets
-        the SDK skip its `http://localhost:8000` default fallback.
+        """Return (ls_host, ls_token) for authenticated LS asset fetches.
+
+        Host resolution is env first, then the cache populated from `/setup`.
+        Token resolution is cache first, then env. Either may be None; callers
+        pass them into `self.get_local_path(ls_host=..., ls_access_token=...)`
+        which lets the SDK skip its `http://localhost:8000` default fallback.
 
         LS's own `/setup` payload can carry `http://localhost:<port>` when
         the LS side doesn't have `HOSTNAME` configured — that's useless to a
-        remote ML backend. The env-var-first ordering means an operator can
-        always override LS's guess via `.env` / `docker-compose`.
+        remote ML backend. The host remains env-var-first so operators can
+        override LS's guess via `.env` / `docker-compose`. The token is
+        cache-first: `/setup` sends the ML-backend access token that LS itself
+        wants us to use, while env tokens are often stale or a frontend refresh
+        JWT that this LS deployment may not accept for API/file downloads.
         """
-        env_host = (os.getenv("LABEL_STUDIO_URL") or "").rstrip("/")
-        env_token = os.getenv("LABEL_STUDIO_API_KEY") or ""
+        env_host = (os.getenv("LABEL_STUDIO_URL") or os.getenv("LABEL_STUDIO_HOST") or "").rstrip("/")
+        env_token = (
+            os.getenv("LABEL_STUDIO_API_KEY")
+            or os.getenv("LABEL_STUDIO_ACCESS_TOKEN")
+            or ""
+        )
         cached_host = (LS_CONTEXT.get("url") or "").rstrip("/")
         cached_token = LS_CONTEXT.get("token") or ""
         host = env_host or cached_host
-        token = env_token or cached_token
+        token = cached_token or env_token
         return (host or None, token or None)
 
     def _download_valid_video(self, raw_url: str, task_id: str) -> str:
@@ -745,9 +757,10 @@ class SamVideoInteractive(LabelStudioMLBase):
         On a bad cache hit, drop the file and re-download once.
         """
         ls_host, ls_token = self._ls_host_token()
+        sdk_token = ls_token_for_sdk(ls_host, ls_token)
         for attempt in range(2):
             local_path = self.get_local_path(
-                raw_url, task_id=task_id, ls_host=ls_host, ls_access_token=ls_token,
+                raw_url, task_id=task_id, ls_host=ls_host, ls_access_token=sdk_token,
             )
             cap = cv2.VideoCapture(local_path)
             ok = cap.isOpened() and cap.read()[0]
@@ -783,10 +796,10 @@ class SamVideoInteractive(LabelStudioMLBase):
         ls_url = ls_url_opt or ""
         api_key = api_key_opt or ""
 
-        def _auth_headers():
-            # Handles both legacy tokens (`Token <key>`) and Personal Access
-            # Tokens (exchanged for a short-lived `Bearer <access>` JWT).
-            return ls_auth_headers(ls_url, api_key)
+        def _auth_headers(target_url: str):
+            # Reuses the LS SDK token/header handling for streaming ffmpeg
+            # requests, including refresh-JWT normalization.
+            return ls_auth_headers(ls_url, api_key, target_url=target_url)
 
         if raw_url.startswith("http://") or raw_url.startswith("https://"):
             # Absolute URL — attach auth iff its host matches the known LS host
@@ -795,15 +808,18 @@ class SamVideoInteractive(LabelStudioMLBase):
             # other host: task data can carry external/presigned cloud URLs and
             # we must not leak the LS token to them.
             attach = should_attach_ls_auth(raw_url, ls_url, bool(api_key))
-            return raw_url, _auth_headers() if attach else None
+            return raw_url, _auth_headers(raw_url) if attach else None
 
         if ls_url and api_key:
             full_url = f"{ls_url}{raw_url}" if raw_url.startswith("/") else f"{ls_url}/{raw_url}"
-            return full_url, _auth_headers()
+            return full_url, _auth_headers(full_url)
 
         logger.warning("streaming not available (no LABEL_STUDIO_URL), falling back to download")
         local_path = self.get_local_path(
-            raw_url, task_id=task_id, ls_host=ls_url_opt, ls_access_token=api_key_opt,
+            raw_url,
+            task_id=task_id,
+            ls_host=ls_url_opt,
+            ls_access_token=ls_token_for_sdk(ls_url_opt, api_key_opt),
         )
         return local_path, None
 

--- a/label_studio_ml/examples/segment_anything_video_interactive/test_ls_auth.py
+++ b/label_studio_ml/examples/segment_anything_video_interactive/test_ls_auth.py
@@ -1,7 +1,7 @@
-"""Unit tests for LS API auth header building (legacy token vs PAT).
+"""Unit tests for LS SDK-backed auth header building.
 
-These run without torch/cv2: the auth logic lives in the dependency-free
-``ls_auth`` module. ``requests`` is stubbed so no network is touched.
+These run without torch/cv2. Refresh-token behavior is stubbed at the SDK
+normalization boundary so no network is touched.
 
 Run with: pytest test_ls_auth.py -v
 """
@@ -17,8 +17,8 @@ import ls_auth
 
 
 def _make_jwt(exp=None, token_type="refresh"):
-    """Build a syntactically valid (unsigned) JWT for testing detection and
-    `exp` parsing. Signature is a dummy — nothing here verifies it."""
+    """Build a syntactically valid unsigned JWT for SDK parsing tests."""
+
     def b64(obj):
         raw = json.dumps(obj).encode()
         return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
@@ -28,108 +28,119 @@ def _make_jwt(exp=None, token_type="refresh"):
     if exp is not None:
         payload_obj["exp"] = exp
     payload = b64(payload_obj)
-    return f"{header}.{payload}.{'sig'}"
+    signature = base64.urlsafe_b64encode(b"sig").rstrip(b"=").decode()
+    return f"{header}.{payload}.{signature}"
+
+
+class _FakeTokensClient:
+    def __init__(self, resolved):
+        self.resolved = resolved
+        self.calls = []
+
+    def resolve_x_api_key_header_value(self, token):
+        self.calls.append(token)
+        return self.resolved
+
+
+class _FakeSdkClient:
+    def __init__(self, resolved):
+        self._client_wrapper = mock.Mock()
+        self._client_wrapper._tokens_client = _FakeTokensClient(resolved)
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
-    """Each test starts with an empty PAT access-token cache."""
-    ls_auth._PAT_ACCESS_CACHE.clear()
+def _clear_sdk_client_cache():
+    ls_auth._SDK_CLIENT_CACHE.clear()
     yield
-    ls_auth._PAT_ACCESS_CACHE.clear()
-
-
-# --- token-type detection -------------------------------------------------
-
-def test_legacy_token_not_detected_as_jwt():
-    assert ls_auth._looks_like_jwt("0123456789abcdef0123456789abcdef01234567") is False
-
-
-def test_pat_detected_as_jwt():
-    assert ls_auth._looks_like_jwt(_make_jwt(exp=9999999999)) is True
-
-
-def test_jwt_exp_parsed():
-    assert ls_auth._jwt_exp(_make_jwt(exp=123456)) == 123456.0
-
-
-def test_jwt_exp_missing_returns_none():
-    assert ls_auth._jwt_exp(_make_jwt(exp=None)) is None
-
-
-def test_jwt_exp_garbage_returns_none():
-    assert ls_auth._jwt_exp("not-a-jwt") is None
+    ls_auth._SDK_CLIENT_CACHE.clear()
 
 
 # --- header building ------------------------------------------------------
+
 
 def test_no_token_returns_none():
     assert ls_auth.ls_auth_headers("http://ls", "") is None
     assert ls_auth.ls_auth_headers("http://ls", None) is None
 
 
-def test_legacy_token_uses_token_scheme():
-    headers = ls_auth.ls_auth_headers("http://ls", "legacytoken123")
-    assert headers == {"Authorization": "Token legacytoken123"}
-
-
-def test_pat_is_exchanged_for_bearer():
-    pat = _make_jwt(exp=9999999999)
-    access = _make_jwt(exp=int(time.time()) + 3600)
-    resp = mock.Mock()
-    resp.json.return_value = {"access": access}
-    resp.raise_for_status.return_value = None
-    with mock.patch.object(ls_auth.requests, "post", return_value=resp) as post:
-        headers = ls_auth.ls_auth_headers("http://ls", pat)
-    assert headers == {"Authorization": f"Bearer {access}"}
-    post.assert_called_once_with(
-        "http://ls/api/token/refresh", json={"refresh": pat},
-        timeout=ls_auth._EXCHANGE_TIMEOUT,
+def test_legacy_token_uses_sdk_token_scheme():
+    headers = ls_auth.ls_auth_headers(
+        "http://ls", "legacytoken123", target_url="http://ls/data/upload/1/video.mp4"
     )
+    assert headers["Authorization"] == "Token legacytoken123"
 
 
-def test_pat_access_token_is_cached():
-    pat = _make_jwt(exp=9999999999)
-    access = _make_jwt(exp=int(time.time()) + 3600)
-    resp = mock.Mock()
-    resp.json.return_value = {"access": access}
-    resp.raise_for_status.return_value = None
-    with mock.patch.object(ls_auth.requests, "post", return_value=resp) as post:
-        ls_auth.ls_auth_headers("http://ls", pat)
-        ls_auth.ls_auth_headers("http://ls", pat)  # second call hits cache
-    post.assert_called_once()  # only one network exchange
+def test_access_jwt_uses_sdk_bearer_scheme_without_refresh():
+    access = _make_jwt(exp=int(time.time()) + 3600, token_type="access")
+
+    with mock.patch.object(ls_auth, "_sdk_client", return_value=_FakeSdkClient(access)) as sdk_client:
+        headers = ls_auth.ls_auth_headers(
+            "http://ls", access, target_url="http://ls/data/upload/1/video.mp4"
+        )
+
+    assert headers["Authorization"] == f"Bearer {access}"
+    sdk_client.assert_called_once_with("http://ls", access)
 
 
-def test_expired_cached_access_token_is_refreshed():
-    pat = _make_jwt(exp=9999999999)
-    # Access token already past the refresh margin → must re-exchange.
-    stale = _make_jwt(exp=int(time.time()) + 10)
-    fresh = _make_jwt(exp=int(time.time()) + 3600)
-    responses = [mock.Mock(), mock.Mock()]
-    responses[0].json.return_value = {"access": stale}
-    responses[1].json.return_value = {"access": fresh}
-    for r in responses:
-        r.raise_for_status.return_value = None
-    with mock.patch.object(ls_auth.requests, "post", side_effect=responses) as post:
-        first = ls_auth.ls_auth_headers("http://ls", pat)
-        second = ls_auth.ls_auth_headers("http://ls", pat)
-    assert first == {"Authorization": f"Bearer {stale}"}
-    assert second == {"Authorization": f"Bearer {fresh}"}
-    assert post.call_count == 2
+def test_refresh_jwt_is_normalized_by_sdk_before_streaming_headers():
+    refresh = _make_jwt(exp=int(time.time()) + 3600, token_type="refresh")
+    access = _make_jwt(exp=int(time.time()) + 3600, token_type="access")
+
+    with mock.patch.object(ls_auth, "_sdk_client", return_value=_FakeSdkClient(access)) as sdk_client:
+        headers = ls_auth.ls_auth_headers(
+            "http://ls", refresh, target_url="http://ls/data/upload/1/video.mp4"
+        )
+
+    assert headers["Authorization"] == f"Bearer {access}"
+    sdk_client.assert_called_once_with("http://ls", refresh)
 
 
-def test_pat_falls_back_to_token_when_exchange_fails():
-    pat = _make_jwt(exp=9999999999)
-    with mock.patch.object(ls_auth.requests, "post", side_effect=Exception("boom")):
-        headers = ls_auth.ls_auth_headers("http://ls", pat)
-    # Degrade to legacy scheme rather than dropping auth entirely.
-    assert headers == {"Authorization": f"Token {pat}"}
+def test_refresh_jwt_is_normalized_by_sdk_before_downloader_fallback():
+    refresh = _make_jwt(exp=int(time.time()) + 3600, token_type="refresh")
+    access = _make_jwt(exp=int(time.time()) + 3600, token_type="access")
+
+    with mock.patch.object(ls_auth, "_sdk_client", return_value=_FakeSdkClient(access)):
+        token = ls_auth.ls_token_for_sdk("http://ls", refresh)
+
+    assert token == access
 
 
-def test_pat_without_host_falls_back_to_token():
-    pat = _make_jwt(exp=9999999999)
-    # No LS host → can't reach the refresh endpoint; don't attempt exchange.
-    with mock.patch.object(ls_auth.requests, "post") as post:
-        headers = ls_auth.ls_auth_headers("", pat)
-    post.assert_not_called()
-    assert headers == {"Authorization": f"Token {pat}"}
+def test_sdk_normalization_failure_preserves_original_token():
+    refresh = _make_jwt(exp=int(time.time()) + 3600, token_type="refresh")
+    fake = mock.Mock()
+    fake._client_wrapper._tokens_client.resolve_x_api_key_header_value.side_effect = RuntimeError("boom")
+
+    with mock.patch.object(ls_auth, "_sdk_client", return_value=fake):
+        token = ls_auth.ls_token_for_sdk("http://ls", refresh)
+
+    assert token == refresh
+
+
+def test_sdk_client_construction_failure_preserves_original_token():
+    refresh = _make_jwt(exp=int(time.time()) + 3600, token_type="refresh")
+
+    with mock.patch.object(ls_auth, "_sdk_client", side_effect=RuntimeError("boom")):
+        token = ls_auth.ls_token_for_sdk("http://ls", refresh)
+
+    assert token == refresh
+
+
+def test_no_ls_host_preserves_token_for_sdk_downloader_fallback():
+    token = "legacytoken123"
+    assert ls_auth.ls_token_for_sdk(None, token) == token
+
+
+def test_headers_attach_for_ls_host_with_scheme_port_difference():
+    headers = ls_auth.ls_auth_headers(
+        "http://app.humansignal.com:80",
+        "legacytoken123",
+        target_url="https://app.humansignal.com/upload/266842/x.mp4",
+    )
+    assert headers["Authorization"] == "Token legacytoken123"
+
+
+def test_sdk_builder_does_not_attach_auth_to_mismatched_host():
+    headers = ls_auth.ls_auth_headers(
+        "http://ls", "legacytoken123", target_url="http://example.com/video.mp4"
+    )
+    assert "Authorization" not in headers


### PR DESCRIPTION
## Summary
- Link: https://humansignal.atlassian.net/browse/BROS-1452
- prefer the `/setup` token for SAM2 video asset fetches while keeping `LABEL_STUDIO_URL` host overrides
- normalize Label Studio JWT/PAT handling for streaming auth headers and SDK download fallback
- add tests for access JWTs and SDK token normalization

## Testing
- `cd label_studio_ml/examples/segment_anything_video_interactive && ../../../.venv/bin/python -m pytest test_ls_auth.py test_video_fetch_retry.py -q`