### PR TITLE
fix: Add missing model property in yolo botsort.yml example.

### DIFF
--- a/label_studio_ml/examples/yolo/models/botsort.yaml
+++ b/label_studio_ml/examples/yolo/models/botsort.yaml
@@ -17,3 +17,4 @@ gmc_method: sparseOptFlow # method of global motion compensation
 proximity_thresh: 0.5
 appearance_thresh: 0.25
 with_reid: False
+model: auto # (str) ReID model name/path; "auto" uses detector features if available


### PR DESCRIPTION
Fix attribute error about missing model attribute when creating video rectangles with botsort tracker.