### PR TITLE
fix: docling -> doclang

### DIFF
--- a/label_studio_ml/examples/docling/README.md
+++ b/label_studio_ml/examples/docling/README.md
@@ -4,7 +4,7 @@
 
 This backend connects Label Studio to **IBM Docling SaaS** using the Python **`DoclingServiceClient`** from the **`docling`** package (`from docling.service_client import DoclingServiceClient`). **Conversion runs on Docling’s servers**, not inside this container. For each task it resolves the file (usually via Label Studio–hosted storage), calls **`client.convert(source=…)`** with a local **`Path`** or an **`https://` URL string**, then maps **`result.document`** into Label Studio predictions for the annotator.
 
-Predictions are emitted as **canonical Label Studio result envelopes** (`type: "rectanglelabels"` / `type: "polygonlabels"`) matching the **HumanSignal Interfaces** Docling annotator at `docling-ls-implementation/docling_interface.jsx`.
+Predictions are emitted as **canonical Label Studio result envelopes** (`type: "rectanglelabels"` / `type: "polygonlabels"`) matching the **HumanSignal Interfaces** Doclang annotator at `doclang/Screen.jsx`.
 
 Use the **exact service URL** your tenant gives you (Integrate / Python snippet), including the path segment ending in **`/v1`**—for example  
 `https://api.aws-c1.dcls.saas.ibm.com/<instance>/v1`.
@@ -67,7 +67,7 @@ The three shape toggles below default to `true` (opt-out) because that's what ma
 - `DOCLING_INCLUDE_TABLE_STRUCTURE` — for every `TableItem`, emit one child rectangle per cell (`table_cell` / `column_header` / `row_header` / `row_section` / `table_merged_cell`) with `parentId` set to the enclosing table. Set to `false` to keep tables as a single flat rect.
 - `DOCLING_INCLUDE_RELATIONS` — emit `to_caption` / `to_footnote` / `to_value` linking polylines from `FloatingItem.captions` / `FloatingItem.footnotes` / `KeyValueItem.graph.links[TO_VALUE]`. Without these, captions become detached free-floating text and key/value fields lose their pairing. Set to `false` to skip.
 
-`DOCLING_FROM_NAME` / `DOCLING_TO_NAME` override the `from_name` / `to_name` on emitted predictions (defaults `"docling"` / `"docling"` — matches the interface).
+`DOCLING_FROM_NAME` / `DOCLING_TO_NAME` override the `from_name` / `to_name` on emitted predictions (defaults `"doclang"` / `"doclang"` — matches the interface).
 
 The **`docling`** PyPI package (**≥2.90**) provides **`DoclingServiceClient`**; behavior follows **your SaaS tenant**, not necessarily open-source Docling docs.
 
@@ -78,7 +78,7 @@ The **`docling`** PyPI package (**≥2.90**) provides **`DoclingServiceClient`**
 | `LABEL_STUDIO_URL` | Base URL of Label Studio, reachable from this backend (see above). |
 | `LABEL_STUDIO_API_KEY` | Token so the backend can download task attachments when needed. |
 
-Predictions are emitted in **canonical Label Studio shape** — `type: "rectanglelabels"` for layout regions and `type: "polygonlabels"` for reading-order polylines, with percent coordinates — matching the HumanSignal Interfaces Docling annotator (`docling-ls-implementation/docling_interface.jsx`).
+Predictions are emitted in **canonical Label Studio shape** — `type: "rectanglelabels"` for layout regions and `type: "polygonlabels"` for reading-order polylines, with percent coordinates — matching the HumanSignal Interfaces Doclang annotator (`doclang/Screen.jsx`).
 
 ## Running locally (without Docker)
 
@@ -120,7 +120,7 @@ You should see a line like **`Docling predict: N task(s)`** whenever you run pre
 Common fixes:
 
 1. **Placeholder URL** — Replace **`YOUR_INSTANCE_SEGMENT`** in **`DOCLING_SERVICE_URL`** with the real path from Workbench.
-2. **Wrong task field** — Tasks must expose a **file URL** under the key your labeling config expects. The default is **`image`** (matches `docling_interface.jsx`); the backend then falls back through `image`, `url`, `ocr`, `$undefined$`, `$undefined`, `undefined`, `pdf`, `document`, `file`. Override with **`DOCLING_TASK_DATA_KEY`** if needed.
+2. **Wrong task field** — Tasks must expose a **file URL** under the key your labeling config expects. The default is **`image`** (matches the Doclang interface's `Screen.jsx`); the backend then falls back through `image`, `url`, `ocr`, `$undefined$`, `$undefined`, `undefined`, `pdf`, `document`, `file`. Override with **`DOCLING_TASK_DATA_KEY`** if needed.
 3. **`LOG_LEVEL`** — Defaults to **`INFO`** in `_wsgi.py` when unset.
 4. **Upload / `/storage-data/` URLs** — `model.py` downloads via **`label_studio_sdk`** using **`LABEL_STUDIO_URL`** (same **scheme + host + port** as in your browser; wrong host breaks auth headers), **`LABEL_STUDIO_API_KEY`**, and network reachability from this container (`host.docker.internal` instead of `localhost` on Docker Desktop). Self-signed HTTPS: set **`VERIFY_SSL=false`** on the ML backend. Logs now include **HTTP status / snippet** when the download fails.
 

--- a/label_studio_ml/examples/docling/docker-compose.yml
+++ b/label_studio_ml/examples/docling/docker-compose.yml
@@ -45,10 +45,10 @@ services:
       # - DOCLING_HTTP_CONNECT_TIMEOUT=30
 
       # Labeling-config overrides. Leave empty unless your project overrides the defaults.
-      # The HumanSignal Interface (docling_interface.jsx) hardcodes
-      # from_name="docling" / to_name="docling" and reads task.data.image, so leave these blank.
-      # - DOCLING_FROM_NAME=docling
-      # - DOCLING_TO_NAME=docling
+      # The HumanSignal Doclang Interface (doclang/Screen.jsx) hardcodes
+      # from_name="doclang" / to_name="doclang" and reads task.data.image, so leave these blank.
+      # - DOCLING_FROM_NAME=doclang
+      # - DOCLING_TO_NAME=doclang
       # - DOCLING_TASK_DATA_KEY=image
 
       # Prediction shape toggles (all default ON — see README for rationale).

--- a/label_studio_ml/examples/docling/docling_to_ls_results.py
+++ b/label_studio_ml/examples/docling/docling_to_ls_results.py
@@ -1,6 +1,6 @@
 """Map DoclingDocument items to canonical Label Studio result entries.
 
-The Docling Interface (``docling-ls-implementation/docling_interface.jsx``,
+The Doclang Interface (``doclang/Screen.jsx``,
 a HumanSignal Interfaces project) reads predictions through its
 ``parseResults`` function and expects canonical Label Studio result shapes.
 This module emits the shapes Docling can populate from a converted document:
@@ -34,7 +34,7 @@ from docling_core.types.doc.labels import DocItemLabel, GraphLinkLabel
 
 logger = logging.getLogger(__name__)
 
-# DoclingDocument labels -> canonical labels used in docling_interface.jsx LABEL_CATEGORIES.
+# DoclingDocument labels -> canonical labels used in the Doclang interface's (Screen.jsx) LABEL_CATEGORIES.
 DOCLING_LABEL_TO_LS: Dict[DocItemLabel, str] = {
     DocItemLabel.TITLE: "section_header",
     DocItemLabel.SECTION_HEADER: "section_header",
@@ -356,7 +356,7 @@ def _make_link_polyline(
     """Build a 2-point ``polygonlabels`` result linking two rectangles.
 
     Used for ``to_caption`` / ``to_footnote`` / ``to_value`` — the label
-    values the interface's ``LINK_RESTRICTIONS`` in ``docling_interface.jsx``
+    values the interface's ``LINK_RESTRICTIONS`` in ``doclang/Screen.jsx``
     expects. Points are the geometric centers of each endpoint; the interface
     snaps them to their enclosing rects on next drag anyway, but drawing at
     the center gives a sensible initial visual.
@@ -530,8 +530,8 @@ def docling_document_to_ls_results(
     include_table_structure: bool = False,
     include_relations: bool = False,
     content_layers: Optional[str] = None,
-    from_name: str = "docling",
-    to_name: str = "docling",
+    from_name: str = "doclang",
+    to_name: str = "doclang",
     score: Optional[float] = None,
 ) -> List[Dict[str, Any]]:
     """Build canonical Label Studio prediction results.

--- a/label_studio_ml/examples/docling/model.py
+++ b/label_studio_ml/examples/docling/model.py
@@ -1,7 +1,7 @@
 """Docling SaaS (IBM) via DoclingServiceClient -> Label Studio predictions.
 
-Predictions target the **HumanSignal Interfaces** Docling annotator
-(``docling-ls-implementation/docling_interface.jsx``), which reads results
+Predictions target the **HumanSignal Interfaces** Doclang annotator
+(``doclang/Screen.jsx``), which reads results
 through ``parseResults``. Output is canonical Label Studio result shapes —
 ``rectanglelabels`` and ``polygonlabels`` — built by
 :mod:`docling_to_ls_results`.
@@ -84,12 +84,12 @@ class Docling(LabelStudioMLBase):
     _client: Optional[DoclingServiceClient] = None
 
     def __init__(self, project_id: Optional[str] = None, label_config: Optional[str] = None, **kwargs):
-        # Optional overrides. The Docling Interface (docling_interface.jsx) hardcodes
-        # from_name="docling" / to_name="docling" and reads task.data.image, so the
+        # Optional overrides. The Doclang Interface (doclang/Screen.jsx) hardcodes
+        # from_name="doclang" / to_name="doclang" and reads task.data.image, so the
         # defaults below match — set these env vars only if your project overrides
         # those names.
-        self._from_name = os.getenv("DOCLING_FROM_NAME") or "docling"
-        self._to_name = os.getenv("DOCLING_TO_NAME") or "docling"
+        self._from_name = os.getenv("DOCLING_FROM_NAME") or "doclang"
+        self._to_name = os.getenv("DOCLING_TO_NAME") or "doclang"
         self._data_key = os.getenv("DOCLING_TASK_DATA_KEY") or "image"
 
         # HumanSignal Interfaces projects ship a near-empty ``<View></View>`` label_config
@@ -163,7 +163,7 @@ class Docling(LabelStudioMLBase):
         return client.convert(source=source, headers=headers or None)
 
     def _task_file_url(self, task: Dict[str, Any]) -> Optional[str]:
-        # Match docling_interface.jsx's resolveImageUrl fallback chain so the ML backend reads from
+        # Match the Doclang interface's (Screen.jsx) resolveImageUrl fallback chain so the ML backend reads from
         # the same place the labeling iframe does — including LSE's ``$undefined$`` direct-upload key
         # (lowercase, with a leading and trailing dollar sign).
         data = task.get("data") or {}
@@ -414,7 +414,7 @@ class Docling(LabelStudioMLBase):
             )
 
         # Canonical Label Studio result shapes (rectanglelabels / polygonlabels),
-        # matching docling_interface.jsx's parseResults contract.
+        # matching the Doclang interface's (Screen.jsx) parseResults contract.
         canonical_results = docling_document_to_ls_results(
             doc,
             page_no=page_no,

--- a/label_studio_ml/examples/docling/test_canonical_results.py
+++ b/label_studio_ml/examples/docling/test_canonical_results.py
@@ -197,6 +197,18 @@ def test_rectanglelabels_envelope_shape() -> None:
     assert v["parentId"] is None
 
 
+def test_default_from_and_to_name_are_doclang() -> None:
+    """Pin the converter's default from_name/to_name. The envelope-shape test above
+    passes them in explicitly and echoes them back, so it stays green for any string;
+    calling with defaults omitted exercises docling_to_ls_results.py's actual defaults
+    and fails if they regress from "doclang" back to "docling"."""
+    item = _item(label=DocItemLabel.SECTION_HEADER, bbox=_tl(10, 20, 30, 40), text="Hello")
+    out = docling_document_to_ls_results(_Doc([(item, 1)]))
+
+    assert len(out) == 1
+    assert out[0]["from_name"] == out[0]["to_name"] == "doclang"
+
+
 def test_bottom_left_origin_bbox_is_flipped_to_top_left() -> None:
     """Docling reports PDF provenance bottom-left; LS wants top-left."""
     # On a 100-high page, a box spanning y=60..80 from the bottom is y=20..40 from the top.

--- a/label_studio_ml/examples/docling/test_canonical_results.py
+++ b/label_studio_ml/examples/docling/test_canonical_results.py
@@ -7,7 +7,7 @@ PDF provenance bbox actually goes through. Only ``iterate_items`` is stubbed, to
 keep the tests independent of IBM Docling SaaS.
 
 They assert the *result envelope shape*, which is the contract that
-``docling-ls-implementation/docling_interface.jsx`` ``parseResults`` reads.
+the Doclang interface's ``doclang/Screen.jsx`` ``parseResults`` reads.
 """
 
 from __future__ import annotations
@@ -172,13 +172,13 @@ def _tl(l: float, t: float, r: float, b: float) -> BoundingBox:
 
 def test_rectanglelabels_envelope_shape() -> None:
     item = _item(label=DocItemLabel.SECTION_HEADER, bbox=_tl(10, 20, 30, 40), text="Hello")
-    out = docling_document_to_ls_results(_Doc([(item, 1)]), from_name="docling", to_name="docling")
+    out = docling_document_to_ls_results(_Doc([(item, 1)]), from_name="doclang", to_name="doclang")
 
     assert len(out) == 1
     r = out[0]
     assert r["type"] == "rectanglelabels"
-    assert r["from_name"] == "docling"
-    assert r["to_name"] == "docling"
+    assert r["from_name"] == "doclang"
+    assert r["to_name"] == "doclang"
     assert r["origin"] == "prediction"
     assert isinstance(r["id"], str) and r["id"]
 

--- a/label_studio_ml/examples/docling/test_model.py
+++ b/label_studio_ml/examples/docling/test_model.py
@@ -63,6 +63,25 @@ def test_no_data_returns_none() -> None:
     assert _url({}) is None
 
 
+def test_default_names_come_from_init(monkeypatch) -> None:
+    """A default-constructed model (no DOCLING_FROM_NAME/DOCLING_TO_NAME set) must
+    wire _from_name/_to_name to "doclang". This exercises __init__'s env-var
+    defaults (model.py) directly — the _model() fixture below hand-assigns the
+    names onto a Docling.__new__() instance, so it would stay green even if those
+    defaults regressed back to "docling", which is the exact regression this PR
+    exists to prevent."""
+    for name in ("DOCLING_FROM_NAME", "DOCLING_TO_NAME", "DOCLING_TASK_DATA_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    # Neutralize the heavy base __init__ (model-server / SDK wiring we don't need here);
+    # the default-name assignment in Docling.__init__ runs before super().__init__().
+    monkeypatch.setattr(model_mod.LabelStudioMLBase, "__init__", lambda self, *a, **k: None)
+
+    m = Docling(project_id="1", label_config=None)
+
+    assert m._from_name == m._to_name == "doclang"
+    assert m._data_key == "image"
+
+
 # --- prediction assembly -------------------------------------------------------------
 #
 # These drive predict_single with the Docling client stubbed out, in both of the modes

--- a/label_studio_ml/examples/docling/test_model.py
+++ b/label_studio_ml/examples/docling/test_model.py
@@ -123,7 +123,7 @@ def _model(monkeypatch, doc, **env) -> Docling:
         monkeypatch.setenv(k, v)
     _stub_convert(monkeypatch, doc)
     m = Docling.__new__(Docling)  # skip __init__: it builds SDK/label-config state we do not need
-    m._data_key, m._from_name, m._to_name = "image", "docling", "docling"
+    m._data_key, m._from_name, m._to_name = "image", "doclang", "doclang"
     return m
 
 


### PR DESCRIPTION
## Summary
Aligns the docling ML backend with the renamed **doclang** HumanSignal Interface. The example previously referenced a `docling` from_name/to_name and `docling_interface.jsx`; the interface control is now `doclang` (`doclang/Screen.jsx`), so predictions must bind to `from_name="doclang"` / `to_name="doclang"`.

## Changes
- `model.py` / `docling_to_ls_results.py`: emit predictions bound to the `doclang` control instead of `docling`.
- `README.md` + `docker-compose.yml`: update docs/comments to reference the `doclang` interface and env var defaults.
- Tests (`test_model.py`, `test_canonical_results.py`): updated expected from_name/to_name.

## Notes
- No functional change beyond the control-name rename; env overrides (`DOCLING_FROM_NAME` / `DOCLING_TO_NAME`) still work for projects that customize the config.
- `docker-compose.yml` keeps placeholder credentials only — no real keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)